### PR TITLE
Rename package to cz.appkazdarma.aiasistent and app name to AI Asistent

### DIFF
--- a/baseline-profile/src/main/java/app/lawnchair/baseline/Constants.kt
+++ b/baseline-profile/src/main/java/app/lawnchair/baseline/Constants.kt
@@ -1,5 +1,5 @@
 package app.lawnchair.baseline
 
 object Constants {
-    val PACKAGE_NAME = "app.lawnchair"
+    val PACKAGE_NAME = "cz.appkazdarma.aiasistent"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -143,7 +143,7 @@ final def quickstepMaxSdk = "35"
 android {
     namespace "com.android.launcher3"
     defaultConfig {
-        // Lawnchair Launcher 15.0 Beta 1
+        // AI Asistent 15.0 Beta 1
         // See CONTRIBUTING.md#versioning-scheme
         versionCode 15_00_02_01
         versionName "${versionDisplayName}"
@@ -161,7 +161,7 @@ android {
     applicationVariants.configureEach { variant ->
         variant.outputs.configureEach {
             def channel = variant.productFlavors.last().name
-            outputFileName = "Lawnchair.${variant.versionName}.$channel.${variant.buildType.name}.apk"
+            outputFileName = "AIAsistent.${variant.versionName}.$channel.${variant.buildType.name}.apk"
         }
     }
 
@@ -232,11 +232,11 @@ android {
 
         debug {
             applicationIdSuffix ".debug"
-            resValue("string", "derived_app_name", "Lawnchair (Debug)")
+            resValue("string", "derived_app_name", "AI Asistent (Debug)")
         }
 
         release {
-            resValue("string", "derived_app_name", "Lawnchair")
+            resValue("string", "derived_app_name", "AI Asistent")
             minifyEnabled true
             shrinkResources true
             proguardFiles proguardFilesFromAosp + "proguard.pro"
@@ -266,17 +266,17 @@ android {
         }
 
         github {
-            applicationId 'app.lawnchair'
+            applicationId 'cz.appkazdarma.aiasistent'
             dimension "channel"
         }
 
         nightly {
-            applicationId 'app.lawnchair.nightly'
+            applicationId 'cz.appkazdarma.aiasistent.nightly'
             dimension "channel"
         }
 
         play {
-            applicationId "app.lawnchair.play"
+            applicationId "cz.appkazdarma.aiasistent.play"
             dimension "channel"
             isDefault true
         }

--- a/res/values-cs/strings.xml
+++ b/res/values-cs/strings.xml
@@ -19,7 +19,7 @@
 
 <resources xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name" msgid="649227358658669779">"Launcher3"</string>
+    <string name="app_name" msgid="649227358658669779">"AI Asistent"</string>
     <string name="work_folder_name" msgid="3753320833950115786">"Práce"</string>
     <string name="activity_not_found" msgid="8071924732094499514">"Aplikace není nainstalována."</string>
     <string name="activity_not_available" msgid="7456344436509528827">"Aplikace není k dispozici."</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -21,7 +21,7 @@
     <skip />
 
     <!-- Application name -->
-    <string name="app_name">Launcher3</string>
+    <string name="app_name">AI Asistent</string>
     <!-- Work folder name -->
     <string name="work_folder_name">Work</string>
     <!-- Displayed when user selects a shortcut for an app that was uninstalled [CHAR_LIMIT=none]-->


### PR DESCRIPTION
## Summary
- Update package IDs to cz.appkazdarma.aiasistent and adjust APK filename prefix
- Rename app label to AI Asistent
- Align baseline profile package constant

## Testing
- `./gradlew tasks` *(fails: Configuring project ':iconloaderlib' without an existing directory is not allowed)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e9bd10808325a335537c1b59fa57