### PR TITLE
Set cz.appkazdarma.aiasistent package and update SDK targets

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -21,7 +21,7 @@
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
-    <uses-sdk android:targetSdkVersion="30" android:minSdkVersion="26"
+    <uses-sdk android:targetSdkVersion="36" android:minSdkVersion="23"
         tools:overrideLibrary="com.kieronquinn.app.smartspacer.sdk.client"/>
     <!--
     Manifest entries specific to Launcher3. This is merged with AndroidManifest-common.xml.

--- a/build.gradle
+++ b/build.gradle
@@ -26,8 +26,8 @@ allprojects {
             buildToolsVersion "36.0.0"
             compileSdk 36
             defaultConfig {
-                minSdk 26
-                targetSdk 35
+                minSdk 23
+                targetSdk 36
                 vectorDrawables.useSupportLibrary = true
             }
             lint {
@@ -127,26 +127,19 @@ final def buildCommit = providers.exec {
     commandLine('git', 'rev-parse', '--short=7', 'HEAD')
 }.standardOutput.asText.get().trim()
 
-final def ciBuild = System.getenv("CI") == "true"
-final def ciRef = System.getenv("GITHUB_REF") ?: ""
-final def ciRunNumber = System.getenv("GITHUB_RUN_NUMBER") ?: ""
-final def isReleaseBuild = ciBuild && ciRef.contains("beta")
-final def devReleaseName = ciBuild ? "Dev.(#${ciRunNumber})" : "Dev.(${buildCommit})"
-final def version = "15"
-final def releaseName = "Beta 1"
-final def versionDisplayName = "${version}.${isReleaseBuild ? releaseName : devReleaseName}"
+final def versionDisplayName = "7.5.8"
 final def majorVersion = versionDisplayName.split("\\.")[0]
 
 final def quickstepMinSdk = "29"
-final def quickstepMaxSdk = "35"
+final def quickstepMaxSdk = "36"
 
 android {
     namespace "com.android.launcher3"
     defaultConfig {
-        // AI Asistent 15.0 Beta 1
-        // See CONTRIBUTING.md#versioning-scheme
-        versionCode 15_00_02_01
+        // AI Asistent 7.5.8
+        versionCode 758
         versionName "${versionDisplayName}"
+        applicationId "cz.appkazdarma.aiasistent"
         buildConfigField "String", "VERSION_DISPLAY_NAME", "\"${versionDisplayName}\""
         buildConfigField "String", "MAJOR_VERSION", "\"${majorVersion}\""
         buildConfigField "String", "COMMIT_HASH", "\"${buildCommit}\""
@@ -268,6 +261,7 @@ android {
         github {
             applicationId 'cz.appkazdarma.aiasistent'
             dimension "channel"
+            isDefault true
         }
 
         nightly {
@@ -278,7 +272,6 @@ android {
         play {
             applicationId "cz.appkazdarma.aiasistent.play"
             dimension "channel"
-            isDefault true
         }
 
         configureEach {

--- a/go/AndroidManifest-launcher.xml
+++ b/go/AndroidManifest-launcher.xml
@@ -19,7 +19,7 @@
 -->
 <manifest
     xmlns:android="http://schemas.android.com/apk/res/android">
-    <uses-sdk android:targetSdkVersion="29" android:minSdkVersion="25"/>
+    <uses-sdk android:targetSdkVersion="36" android:minSdkVersion="23"/>
     <!--
     Manifest entries specific to Launcher3. This is merged with AndroidManifest-common.xml.
     Refer comments around specific entries on how to extend individual components.

--- a/go/AndroidManifest.xml
+++ b/go/AndroidManifest.xml
@@ -21,7 +21,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <uses-sdk android:targetSdkVersion="29" android:minSdkVersion="25"/>
+    <uses-sdk android:targetSdkVersion="36" android:minSdkVersion="23"/>
 
     <uses-permission android:name="android.permission.GET_TOP_ACTIVITY_INFO" />
 

--- a/quickstep/AndroidManifest-launcher.xml
+++ b/quickstep/AndroidManifest-launcher.xml
@@ -23,7 +23,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <uses-sdk android:targetSdkVersion="33" android:minSdkVersion="26"
+    <uses-sdk android:targetSdkVersion="36" android:minSdkVersion="23"
         tools:overrideLibrary="com.kieronquinn.app.smartspacer.sdk.client"/>
     
     <!--

--- a/systemUI/plugin_core/AndroidManifest.xml
+++ b/systemUI/plugin_core/AndroidManifest.xml
@@ -18,7 +18,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.android.systemui.plugin_core">
 
-    <uses-sdk
-        android:minSdkVersion="28" />
+    <uses-sdk android:minSdkVersion="23" android:targetSdkVersion="36" />
 
 </manifest>

--- a/tests/AndroidManifest.xml
+++ b/tests/AndroidManifest.xml
@@ -18,7 +18,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.android.launcher3.tests">
 
-    <uses-sdk android:targetSdkVersion="29" android:minSdkVersion="25"
+    <uses-sdk android:targetSdkVersion="36" android:minSdkVersion="23"
               tools:overrideLibrary="android.support.test.uiautomator.v18"/>
 
     <application android:debuggable="true">

--- a/tests/multivalentTests/dummy_app/AndroidManifest.xml
+++ b/tests/multivalentTests/dummy_app/AndroidManifest.xml
@@ -21,7 +21,7 @@
      to come from a domain that you own or have control over. -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.android.aardwolf">
-    <uses-sdk android:targetSdkVersion="29" android:minSdkVersion="21"/>
+    <uses-sdk android:targetSdkVersion="36" android:minSdkVersion="23"/>
     <application android:label="Aardwolf">
         <activity
             android:name="Activity1"

--- a/wmshell/tests/flicker/appcompat/AndroidManifest.xml
+++ b/wmshell/tests/flicker/appcompat/AndroidManifest.xml
@@ -18,7 +18,7 @@
           xmlns:tools="http://schemas.android.com/tools"
           package="com.android.wm.shell.flicker">
 
-    <uses-sdk android:minSdkVersion="29" android:targetSdkVersion="29"/>
+    <uses-sdk android:minSdkVersion="23" android:targetSdkVersion="36"/>
     <!-- Read and write traces from external storage -->
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />

--- a/wmshell/tests/flicker/bubble/AndroidManifest.xml
+++ b/wmshell/tests/flicker/bubble/AndroidManifest.xml
@@ -18,7 +18,7 @@
           xmlns:tools="http://schemas.android.com/tools"
           package="com.android.wm.shell.flicker.bubble">
 
-    <uses-sdk android:minSdkVersion="29" android:targetSdkVersion="29"/>
+    <uses-sdk android:minSdkVersion="23" android:targetSdkVersion="36"/>
     <!-- Read and write traces from external storage -->
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />

--- a/wmshell/tests/flicker/pip/AndroidManifest.xml
+++ b/wmshell/tests/flicker/pip/AndroidManifest.xml
@@ -18,7 +18,7 @@
           xmlns:tools="http://schemas.android.com/tools"
           package="com.android.wm.shell.flicker.pip">
 
-    <uses-sdk android:minSdkVersion="29" android:targetSdkVersion="29"/>
+    <uses-sdk android:minSdkVersion="23" android:targetSdkVersion="36"/>
     <!-- Read and write traces from external storage -->
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />

--- a/wmshell/tests/flicker/service/AndroidManifest.xml
+++ b/wmshell/tests/flicker/service/AndroidManifest.xml
@@ -18,7 +18,7 @@
           xmlns:tools="http://schemas.android.com/tools"
           package="com.android.wm.shell.flicker.service">
 
-    <uses-sdk android:minSdkVersion="29" android:targetSdkVersion="29"/>
+    <uses-sdk android:minSdkVersion="23" android:targetSdkVersion="36"/>
     <!-- Read and write traces from external storage -->
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />

--- a/wmshell/tests/flicker/splitscreen/AndroidManifest.xml
+++ b/wmshell/tests/flicker/splitscreen/AndroidManifest.xml
@@ -18,7 +18,7 @@
           xmlns:tools="http://schemas.android.com/tools"
           package="com.android.wm.shell.flicker.splitscreen">
 
-    <uses-sdk android:minSdkVersion="29" android:targetSdkVersion="29"/>
+    <uses-sdk android:minSdkVersion="23" android:targetSdkVersion="36"/>
     <!-- Read and write traces from external storage -->
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />


### PR DESCRIPTION
## Summary
- Set application ID to `cz.appkazdarma.aiasistent` with version 7.5.8/758
- Lower minSdk to 23 and raise targetSdk to 36 across build and manifests
- Make the `github` flavor default for builds

## Testing
- `./gradlew assembleGithubDebug` *(fails: Configuring project ':iconloaderlib' without an existing directory is not allowed)*

------
https://chatgpt.com/codex/tasks/task_e_68b212476838832586a4daddc1ce1da0