### PR TITLE
Align Play flavor package name with store listing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -270,7 +270,7 @@ android {
         }
 
         play {
-            applicationId "cz.appkazdarma.aiasistent.play"
+            applicationId "cz.appkazdarma.aiasistent"
             dimension "channel"
         }
 


### PR DESCRIPTION
## Summary
- ensure Play build uses package name `cz.appkazdarma.aiasistent`

## Testing
- `./gradlew assemblePlayRelease` *(fails: Configuring project ':iconloaderlib' without an existing directory is not allowed)*

------
https://chatgpt.com/codex/tasks/task_e_68b215ec3220832586886b2fe4863de2