### PR TITLE
Replace Lawnchair branding and remove beta banner

### DIFF
--- a/lawnchair/res/values-af-rZA/strings.xml
+++ b/lawnchair/res/values-af-rZA/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI assistent
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@
     <string name="time_weeks_ago">%dw</string>
     <string name="time_months_ago">%dmo</string>
     <string name="time_years_ago">%dy</string>
-    <string name="managed_by_lawnchair">Managed by Lawnchair</string>
+    <string name="managed_by_lawnchair">Managed by AI assistent</string>
     <!-- When mentioning settings UI -->
     <string name="smartspace_preferences">Voorkeure</string>
     <string name="settings_button_text">Home settings</string>
@@ -69,7 +69,7 @@
     <string name="title_change_settings">Change settings</string>
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout AI assistent
 
     -->
     <string name="others_category_label">Others</string>
@@ -114,7 +114,7 @@
     <string name="folders_filter_duplicates">Only show unique apps</string>
     <string name="my_folder_label">My folder</string>
     <!-- A11y description -->
-    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, Lawnchair uses the performGlobalAction Accessibility service.</string>
+    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, AI assistent requires accessibility access.\n\nAI assistent doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. AI assistent discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, AI assistent uses the performGlobalAction Accessibility service.</string>
     <string name="x_with_y_count">%1$s (%2$d)</string>
     <string name="x_by_y">%1$d x %2$d</string>
     <string name="x_and_y">%1$s &amp; %2$s</string>
@@ -143,7 +143,7 @@
     <string name="quickstep_description">Clear All button, corner radius</string>
     <string name="about_label">Oor</string>
     <string name="app_info_drop_target_label">App info</string>
-    <string name="debug_restart_launcher">Herbegin Lawnchair</string>
+    <string name="debug_restart_launcher">Herbegin AI assistent</string>
     <string name="experimental_features_label">Experimental features</string>
     <!-- Experimental features -->
     <string name="font_picker_label">Font customization</string>
@@ -171,7 +171,7 @@
     Notifications
 
     -->
-    <string name="set_default_launcher_tip">To access shortcuts and additional features, set Lawnchair as your default launcher</string>
+    <string name="set_default_launcher_tip">To access shortcuts and additional features, set AI assistent as your default launcher</string>
     <string name="notification_dots">Notification dots</string>
     <string name="show_notification_count">Show notification counter</string>
     <string name="notification_dots_color">Notification dot color</string>
@@ -344,7 +344,7 @@
     <string name="event_provider_missing_notification_dots">To use <xliff:g example="My Provider" id="providerName">%1$s</xliff:g>, turn on Notification Dots.</string>
     <!-- Toggle button for enabling Smartspace -->
     <string name="smartspace_widget_toggle_label">Show on home screen</string>
-    <string name="smartspace_widget_toggle_description">At a Glance can be manually added to the home screen by placing the Lawnchair widget</string>
+    <string name="smartspace_widget_toggle_description">At a Glance can be manually added to the home screen by placing the AI assistent widget</string>
     <!-- List of available providers -->
     <string name="smartspace_mode_label">At a Glance provider</string>
     <string name="smartspace_mode_google">Google</string>
@@ -415,18 +415,18 @@
     <string name="gesture_handler_open_assistant">Open assistant</string>
     <string name="pick_app_for_gesture">Pick app</string>
     <string name="dt2s_admin_hint_title">Admin permissions required</string>
-    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set Lawnchair as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
+    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set AI assistent as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
     <string name="dt2s_admin_warning">Dubbeltik om te slaap sal afgeskakel word.</string>
     <string name="d2ts_recents_a11y_hint_title">Turn on accessibility service</string>
-    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the AI assistent accessibility service. Tap \"Open settings\", select \"AI assistent\" and turn on \"Use AI assistent.\"\n\nAI assistent uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, AI assistent is not configured for that functionality and receives no events.</string>
     <string name="dt2s_recents_warning_open_settings">Open settings</string>
-    <string name="recents_a11y_hint">To use Open Recents screen, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="recents_a11y_hint">To use Open Recents screen, turn on the AI assistent accessibility service. Tap \"Open settings\", select \"AI assistent\" and turn on \"Use AI assistent.\"\n\nAI assistent uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, AI assistent is not configured for that functionality and receives no events.</string>
     <!--
 
     Bug reporting
 
     -->
-    <string name="lawnchair_bug_report">Lawnchair bug report</string>
+    <string name="lawnchair_bug_report">AI assistent bug report</string>
     <string name="crash_report_notif_title">%1$s crashed</string>
     <string name="action_upload_crash_report">Upload crash log</string>
     <string name="action_upload_error">Oplaai het misluk</string>
@@ -519,7 +519,7 @@
     <!-- Search providers -->
     <string name="search_provider_app_search">App search</string>
     <string name="search_provider_custom">Pasgemaak</string>
-    <string name="search_provider_sponsored_description">%1$s and Lawnchair have a revenue share agreement.\n\nSearching with %1$s helps support Lawnchair.</string>
+    <string name="search_provider_sponsored_description">%1$s and AI assistent have a revenue share agreement.\n\nSearching with %1$s helps support AI assistent.</string>
     <string name="app_label">App</string>
     <string name="website_label">Website</string>
     <string name="qsb_search_provider_app_required">App required</string>
@@ -552,7 +552,7 @@
     <string name="max_folder_columns">Maximum folder columns</string>
     <string name="max_folder_rows">Maximum folder rows</string>
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">These settings will be ignored as Lawnchair isn\'t set as the Recents screen provider</string>
+    <string name="quickswitch_ignored_warning">These settings will be ignored as AI assistent isn\'t set as the Recents screen provider</string>
     <string name="quickstep_incompatible">Incompatible system integration</string>
     <string name="quickstep_incompatible_description">Your device is configured to have system gestures (known as Quickstep) provided by %1$s, but this version of %1$s isn\'t compatible with your Android version. To continue using your device, please uninstall %1$s updates or disable %1$s as a system gesture provider.</string>
     <string name="translucent_background">Translucent background</string>

--- a/lawnchair/res/values-af/strings.xml
+++ b/lawnchair/res/values-af/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI assistent
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-am-rET/strings.xml
+++ b/lawnchair/res/values-am-rET/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, ረዳት ረዳት
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@
     <string name="time_weeks_ago">%dw</string>
     <string name="time_months_ago">%dmo</string>
     <string name="time_years_ago">%dy</string>
-    <string name="managed_by_lawnchair">Managed by Lawnchair</string>
+    <string name="managed_by_lawnchair">Managed by ረዳት ረዳት</string>
     <!-- When mentioning settings UI -->
     <string name="smartspace_preferences">Preferences</string>
     <string name="settings_button_text">Home settings</string>
@@ -69,7 +69,7 @@
     <string name="title_change_settings">Change settings</string>
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout ረዳት ረዳት
 
     -->
     <string name="others_category_label">Others</string>
@@ -114,7 +114,7 @@
     <string name="folders_filter_duplicates">Only show unique apps</string>
     <string name="my_folder_label">My folder</string>
     <!-- A11y description -->
-    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, Lawnchair uses the performGlobalAction Accessibility service.</string>
+    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, ረዳት ረዳት requires accessibility access.\n\nረዳት ረዳት doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. ረዳት ረዳት discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, ረዳት ረዳት uses the performGlobalAction Accessibility service.</string>
     <string name="x_with_y_count">%1$s (%2$d)</string>
     <string name="x_by_y">%1$d x %2$d</string>
     <string name="x_and_y">%1$s &amp; %2$s</string>
@@ -143,7 +143,7 @@
     <string name="quickstep_description">Clear All button, corner radius</string>
     <string name="about_label">About</string>
     <string name="app_info_drop_target_label">App info</string>
-    <string name="debug_restart_launcher">Restart Lawnchair</string>
+    <string name="debug_restart_launcher">Restart ረዳት ረዳት</string>
     <string name="experimental_features_label">Experimental features</string>
     <!-- Experimental features -->
     <string name="font_picker_label">Font customization</string>
@@ -171,7 +171,7 @@
     Notifications
 
     -->
-    <string name="set_default_launcher_tip">To access shortcuts and additional features, set Lawnchair as your default launcher</string>
+    <string name="set_default_launcher_tip">To access shortcuts and additional features, set ረዳት ረዳት as your default launcher</string>
     <string name="notification_dots">Notification dots</string>
     <string name="show_notification_count">Show notification counter</string>
     <string name="notification_dots_color">Notification dot color</string>
@@ -344,7 +344,7 @@
     <string name="event_provider_missing_notification_dots">To use <xliff:g example="My Provider" id="providerName">%1$s</xliff:g>, turn on Notification Dots.</string>
     <!-- Toggle button for enabling Smartspace -->
     <string name="smartspace_widget_toggle_label">Show on home screen</string>
-    <string name="smartspace_widget_toggle_description">At a Glance can be manually added to the home screen by placing the Lawnchair widget</string>
+    <string name="smartspace_widget_toggle_description">At a Glance can be manually added to the home screen by placing the ረዳት ረዳት widget</string>
     <!-- List of available providers -->
     <string name="smartspace_mode_label">At a Glance provider</string>
     <string name="smartspace_mode_google">Google</string>
@@ -415,18 +415,18 @@
     <string name="gesture_handler_open_assistant">Open assistant</string>
     <string name="pick_app_for_gesture">Pick app</string>
     <string name="dt2s_admin_hint_title">Admin permissions required</string>
-    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set Lawnchair as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
+    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set ረዳት ረዳት as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
     <string name="dt2s_admin_warning">Double-Tap to Sleep will be turned off.</string>
     <string name="d2ts_recents_a11y_hint_title">Turn on accessibility service</string>
-    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the ረዳት ረዳት accessibility service. Tap \"Open settings\", select \"ረዳት ረዳት\" and turn on \"Use ረዳት ረዳት.\"\n\nረዳት ረዳት uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, ረዳት ረዳት is not configured for that functionality and receives no events.</string>
     <string name="dt2s_recents_warning_open_settings">Open settings</string>
-    <string name="recents_a11y_hint">To use Open Recents screen, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="recents_a11y_hint">To use Open Recents screen, turn on the ረዳት ረዳት accessibility service. Tap \"Open settings\", select \"ረዳት ረዳት\" and turn on \"Use ረዳት ረዳት.\"\n\nረዳት ረዳት uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, ረዳት ረዳት is not configured for that functionality and receives no events.</string>
     <!--
 
     Bug reporting
 
     -->
-    <string name="lawnchair_bug_report">Lawnchair bug report</string>
+    <string name="lawnchair_bug_report">ረዳት ረዳት bug report</string>
     <string name="crash_report_notif_title">%1$s crashed</string>
     <string name="action_upload_crash_report">Upload crash log</string>
     <string name="action_upload_error">Upload failed</string>
@@ -519,7 +519,7 @@
     <!-- Search providers -->
     <string name="search_provider_app_search">App search</string>
     <string name="search_provider_custom">Custom</string>
-    <string name="search_provider_sponsored_description">%1$s and Lawnchair have a revenue share agreement.\n\nSearching with %1$s helps support Lawnchair.</string>
+    <string name="search_provider_sponsored_description">%1$s and ረዳት ረዳት have a revenue share agreement.\n\nSearching with %1$s helps support ረዳት ረዳት.</string>
     <string name="app_label">App</string>
     <string name="website_label">Website</string>
     <string name="qsb_search_provider_app_required">App required</string>
@@ -552,7 +552,7 @@
     <string name="max_folder_columns">Maximum folder columns</string>
     <string name="max_folder_rows">Maximum folder rows</string>
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">These settings will be ignored as Lawnchair isn\'t set as the Recents screen provider</string>
+    <string name="quickswitch_ignored_warning">These settings will be ignored as ረዳት ረዳት isn\'t set as the Recents screen provider</string>
     <string name="quickstep_incompatible">Incompatible system integration</string>
     <string name="quickstep_incompatible_description">Your device is configured to have system gestures (known as Quickstep) provided by %1$s, but this version of %1$s isn\'t compatible with your Android version. To continue using your device, please uninstall %1$s updates or disable %1$s as a system gesture provider.</string>
     <string name="translucent_background">Translucent background</string>

--- a/lawnchair/res/values-am/strings.xml
+++ b/lawnchair/res/values-am/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, ረዳት ረዳት
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-ar-rSA/strings.xml
+++ b/lawnchair/res/values-ar-rSA/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, مساعد منظمة العفو الدولية
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@
     <string name="time_weeks_ago">%dw</string>
     <string name="time_months_ago">%dmo</string>
     <string name="time_years_ago">%dy</string>
-    <string name="managed_by_lawnchair">تتم الإدارة بواسطة Lawnchair</string>
+    <string name="managed_by_lawnchair">تتم الإدارة بواسطة مساعد منظمة العفو الدولية</string>
     <!-- When mentioning settings UI -->
     <string name="smartspace_preferences">التفضيلات</string>
     <string name="settings_button_text">إعدادات الصفحة الرئيسية</string>
@@ -69,7 +69,7 @@
     <string name="title_change_settings">تغيير الإعدادات</string>
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout مساعد منظمة العفو الدولية
 
     -->
     <string name="others_category_label">آحرون</string>
@@ -114,7 +114,7 @@
     <string name="folders_filter_duplicates">إظهار التطبيقات الفريدة فقط</string>
     <string name="my_folder_label">مجلدي</string>
     <!-- A11y description -->
-    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, Lawnchair uses the performGlobalAction Accessibility service.</string>
+    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, مساعد منظمة العفو الدولية requires accessibility access.\n\nمساعد منظمة العفو الدولية doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. مساعد منظمة العفو الدولية discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, مساعد منظمة العفو الدولية uses the performGlobalAction Accessibility service.</string>
     <string name="x_with_y_count">%1$s (%2$d)</string>
     <string name="x_by_y">%1$d x %2$d</string>
     <string name="x_and_y">%1$s &amp; %2$s</string>
@@ -143,7 +143,7 @@
     <string name="quickstep_description">زر \"مسح الكل\"، نصف قطر الزاوية</string>
     <string name="about_label">حول التطبيق</string>
     <string name="app_info_drop_target_label">معلومات التطبيق</string>
-    <string name="debug_restart_launcher">إعادة تشغيل Lawnchair</string>
+    <string name="debug_restart_launcher">إعادة تشغيل مساعد منظمة العفو الدولية</string>
     <string name="experimental_features_label">الميزات التجريبية</string>
     <!-- Experimental features -->
     <string name="font_picker_label">تخصيص الخط</string>
@@ -171,7 +171,7 @@
     Notifications
 
     -->
-    <string name="set_default_launcher_tip">للوصول إلى الاختصارات والميزات الإضافية، عيّن Lawnchair كمشغل افتراضي</string>
+    <string name="set_default_launcher_tip">للوصول إلى الاختصارات والميزات الإضافية، عيّن مساعد منظمة العفو الدولية كمشغل افتراضي</string>
     <string name="notification_dots">نقاط الإشعارات</string>
     <string name="show_notification_count">عرض عداد الإشعارات</string>
     <string name="notification_dots_color">لون نقطة الإشعار</string>
@@ -344,7 +344,7 @@
     <string name="event_provider_missing_notification_dots">لاستخدام <xliff:g example="My Provider" id="providerName">%1$s</xliff:g>، قم بتفعيل نقاط الإشعارات.</string>
     <!-- Toggle button for enabling Smartspace -->
     <string name="smartspace_widget_toggle_label">عرض على الشاشة الرئيسية</string>
-    <string name="smartspace_widget_toggle_description">يمكنك إضافة لمحة يدوياً إلى الشاشة الرئيسية عن طريق وضع ويدجيت Lawnchair</string>
+    <string name="smartspace_widget_toggle_description">يمكنك إضافة لمحة يدوياً إلى الشاشة الرئيسية عن طريق وضع ويدجيت مساعد منظمة العفو الدولية</string>
     <!-- List of available providers -->
     <string name="smartspace_mode_label">مزود لمحة</string>
     <string name="smartspace_mode_google">جوجل</string>
@@ -415,18 +415,18 @@
     <string name="gesture_handler_open_assistant">مساعد مفتوح</string>
     <string name="pick_app_for_gesture">اختر التطبيق</string>
     <string name="dt2s_admin_hint_title">أذونات المشرف مطلوبة</string>
-    <string name="dt2s_admin_hint">لاستخدام النقرة المزدوجة لإطفاء الشاشة، عيّن Lawnchair كتطبيق مشرف للجهاز. انقر على فتح الإعدادات، ثم انقر على \"فعِّل التطبيق كمشرف على الجهاز.\"</string>
+    <string name="dt2s_admin_hint">لاستخدام النقرة المزدوجة لإطفاء الشاشة، عيّن مساعد منظمة العفو الدولية كتطبيق مشرف للجهاز. انقر على فتح الإعدادات، ثم انقر على \"فعِّل التطبيق كمشرف على الجهاز.\"</string>
     <string name="dt2s_admin_warning">سيتم إيقاف تشغيل الضغط المزدوج للسكون.</string>
     <string name="d2ts_recents_a11y_hint_title">تشغيل خدمة الوصول</string>
-    <string name="dt2s_a11y_hint">لاستخدام ميزة النقر المزدوج للسكون، قم بتفعيل خدمة الوصول الخاصة بـ Lawnchair. اضغط على \"فتح الإعدادات\"، ثم اختر \"Lawnchair\" وقم بتفعيل \"استخدام Lawnchair\". يستخدم Lawnchair طريقة performGlobalAction من خدمات الوصول لتنفيذ هذا الإجراء. هذه إذن حساس يسمح بمراقبة التطبيقات الأخرى. ومع ذلك، لم يتم تكوين Lawnchair لهذه الوظيفة ولا يستقبل أي أحداث.</string>
+    <string name="dt2s_a11y_hint">لاستخدام ميزة النقر المزدوج للسكون، قم بتفعيل خدمة الوصول الخاصة بـ مساعد منظمة العفو الدولية. اضغط على \"فتح الإعدادات\"، ثم اختر \"مساعد منظمة العفو الدولية\" وقم بتفعيل \"استخدام مساعد منظمة العفو الدولية\". يستخدم مساعد منظمة العفو الدولية طريقة performGlobalAction من خدمات الوصول لتنفيذ هذا الإجراء. هذه إذن حساس يسمح بمراقبة التطبيقات الأخرى. ومع ذلك، لم يتم تكوين مساعد منظمة العفو الدولية لهذه الوظيفة ولا يستقبل أي أحداث.</string>
     <string name="dt2s_recents_warning_open_settings">فتح الإعدادات</string>
-    <string name="recents_a11y_hint">To use Open Recents screen, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="recents_a11y_hint">To use Open Recents screen, turn on the مساعد منظمة العفو الدولية accessibility service. Tap \"Open settings\", select \"مساعد منظمة العفو الدولية\" and turn on \"Use مساعد منظمة العفو الدولية.\"\n\nمساعد منظمة العفو الدولية uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, مساعد منظمة العفو الدولية is not configured for that functionality and receives no events.</string>
     <!--
 
     Bug reporting
 
     -->
-    <string name="lawnchair_bug_report">تقرير خطأ Lawnchair</string>
+    <string name="lawnchair_bug_report">تقرير خطأ مساعد منظمة العفو الدولية</string>
     <string name="crash_report_notif_title">%1$s تعطل</string>
     <string name="action_upload_crash_report">تحميل سجل التعطل</string>
     <string name="action_upload_error">فشل التحميل</string>
@@ -519,7 +519,7 @@
     <!-- Search providers -->
     <string name="search_provider_app_search">بحث التطبيقات</string>
     <string name="search_provider_custom">تخصيص</string>
-    <string name="search_provider_sponsored_description">%1$s وLawnchair لديهما اتفاقية مشاركة الإيرادات.\n\nالبحث باستخدام %1$s يساعد في دعم Lawnchair.</string>
+    <string name="search_provider_sponsored_description">%1$s ومساعد منظمة العفو الدولية لديهما اتفاقية مشاركة الإيرادات.\n\nالبحث باستخدام %1$s يساعد في دعم مساعد منظمة العفو الدولية.</string>
     <string name="app_label">التطبيق</string>
     <string name="website_label">الموقع</string>
     <string name="qsb_search_provider_app_required">التطبيق مطلوب</string>
@@ -556,7 +556,7 @@
     <string name="max_folder_columns">أقصى عدد من الأعمدة في المجلد</string>
     <string name="max_folder_rows">أقصى عدد من الصفوف في المجلد</string>
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">These settings will be ignored as Lawnchair isn\'t set as the Recents screen provider</string>
+    <string name="quickswitch_ignored_warning">These settings will be ignored as مساعد منظمة العفو الدولية isn\'t set as the Recents screen provider</string>
     <string name="quickstep_incompatible">تكامل النظام غير متوافق</string>
     <string name="quickstep_incompatible_description">تم تكوين جهازك ليحتوي على إيماءات النظام (المعروفة باسم Quickstep) المقدمة بواسطة %1$s، ولكن هذا الإصدار من %1$s غير متوافق مع إصدار Android الخاص بك. لمتابعة استخدام جهازك، يرجى إلغاء تثبيت تحديثات %1$s أو تعطيل %1$s كمزود لإيماءات النظام.</string>
     <string name="translucent_background">خلفية شفافة</string>

--- a/lawnchair/res/values-ar-rXB/strings.xml
+++ b/lawnchair/res/values-ar-rXB/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, مساعد منظمة العفو الدولية
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-ar/strings.xml
+++ b/lawnchair/res/values-ar/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, مساعد منظمة العفو الدولية
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-as/strings.xml
+++ b/lawnchair/res/values-as/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI সহায়ক
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-az-rAZ/strings.xml
+++ b/lawnchair/res/values-az-rAZ/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI köməkçisi
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@
     <string name="time_weeks_ago">%dw</string>
     <string name="time_months_ago">%dmo</string>
     <string name="time_years_ago">%dy</string>
-    <string name="managed_by_lawnchair">Managed by Lawnchair</string>
+    <string name="managed_by_lawnchair">Managed by AI köməkçisi</string>
     <!-- When mentioning settings UI -->
     <string name="smartspace_preferences">Preferences</string>
     <string name="settings_button_text">Home settings</string>
@@ -69,7 +69,7 @@
     <string name="title_change_settings">Change settings</string>
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout AI köməkçisi
 
     -->
     <string name="others_category_label">Others</string>
@@ -114,7 +114,7 @@
     <string name="folders_filter_duplicates">Only show unique apps</string>
     <string name="my_folder_label">My folder</string>
     <!-- A11y description -->
-    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, Lawnchair uses the performGlobalAction Accessibility service.</string>
+    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, AI köməkçisi requires accessibility access.\n\nAI köməkçisi doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. AI köməkçisi discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, AI köməkçisi uses the performGlobalAction Accessibility service.</string>
     <string name="x_with_y_count">%1$s (%2$d)</string>
     <string name="x_by_y">%1$d x %2$d</string>
     <string name="x_and_y">%1$s &amp; %2$s</string>
@@ -143,7 +143,7 @@
     <string name="quickstep_description">Clear All button, corner radius</string>
     <string name="about_label">About</string>
     <string name="app_info_drop_target_label">App info</string>
-    <string name="debug_restart_launcher">Restart Lawnchair</string>
+    <string name="debug_restart_launcher">Restart AI köməkçisi</string>
     <string name="experimental_features_label">Experimental features</string>
     <!-- Experimental features -->
     <string name="font_picker_label">Font customization</string>
@@ -171,7 +171,7 @@
     Notifications
 
     -->
-    <string name="set_default_launcher_tip">To access shortcuts and additional features, set Lawnchair as your default launcher</string>
+    <string name="set_default_launcher_tip">To access shortcuts and additional features, set AI köməkçisi as your default launcher</string>
     <string name="notification_dots">Notification dots</string>
     <string name="show_notification_count">Show notification counter</string>
     <string name="notification_dots_color">Notification dot color</string>
@@ -344,7 +344,7 @@
     <string name="event_provider_missing_notification_dots">To use <xliff:g example="My Provider" id="providerName">%1$s</xliff:g>, turn on Notification Dots.</string>
     <!-- Toggle button for enabling Smartspace -->
     <string name="smartspace_widget_toggle_label">Show on home screen</string>
-    <string name="smartspace_widget_toggle_description">At a Glance can be manually added to the home screen by placing the Lawnchair widget</string>
+    <string name="smartspace_widget_toggle_description">At a Glance can be manually added to the home screen by placing the AI köməkçisi widget</string>
     <!-- List of available providers -->
     <string name="smartspace_mode_label">At a Glance provider</string>
     <string name="smartspace_mode_google">Google</string>
@@ -415,18 +415,18 @@
     <string name="gesture_handler_open_assistant">Open assistant</string>
     <string name="pick_app_for_gesture">Pick app</string>
     <string name="dt2s_admin_hint_title">Admin permissions required</string>
-    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set Lawnchair as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
+    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set AI köməkçisi as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
     <string name="dt2s_admin_warning">Double-Tap to Sleep will be turned off.</string>
     <string name="d2ts_recents_a11y_hint_title">Turn on accessibility service</string>
-    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the AI köməkçisi accessibility service. Tap \"Open settings\", select \"AI köməkçisi\" and turn on \"Use AI köməkçisi.\"\n\nAI köməkçisi uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, AI köməkçisi is not configured for that functionality and receives no events.</string>
     <string name="dt2s_recents_warning_open_settings">Open settings</string>
-    <string name="recents_a11y_hint">To use Open Recents screen, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="recents_a11y_hint">To use Open Recents screen, turn on the AI köməkçisi accessibility service. Tap \"Open settings\", select \"AI köməkçisi\" and turn on \"Use AI köməkçisi.\"\n\nAI köməkçisi uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, AI köməkçisi is not configured for that functionality and receives no events.</string>
     <!--
 
     Bug reporting
 
     -->
-    <string name="lawnchair_bug_report">Lawnchair bug report</string>
+    <string name="lawnchair_bug_report">AI köməkçisi bug report</string>
     <string name="crash_report_notif_title">%1$s crashed</string>
     <string name="action_upload_crash_report">Upload crash log</string>
     <string name="action_upload_error">Upload failed</string>
@@ -519,7 +519,7 @@
     <!-- Search providers -->
     <string name="search_provider_app_search">App search</string>
     <string name="search_provider_custom">Custom</string>
-    <string name="search_provider_sponsored_description">%1$s and Lawnchair have a revenue share agreement.\n\nSearching with %1$s helps support Lawnchair.</string>
+    <string name="search_provider_sponsored_description">%1$s and AI köməkçisi have a revenue share agreement.\n\nSearching with %1$s helps support AI köməkçisi.</string>
     <string name="app_label">App</string>
     <string name="website_label">Website</string>
     <string name="qsb_search_provider_app_required">App required</string>
@@ -552,7 +552,7 @@
     <string name="max_folder_columns">Maximum folder columns</string>
     <string name="max_folder_rows">Maximum folder rows</string>
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">These settings will be ignored as Lawnchair isn\'t set as the Recents screen provider</string>
+    <string name="quickswitch_ignored_warning">These settings will be ignored as AI köməkçisi isn\'t set as the Recents screen provider</string>
     <string name="quickstep_incompatible">Incompatible system integration</string>
     <string name="quickstep_incompatible_description">Your device is configured to have system gestures (known as Quickstep) provided by %1$s, but this version of %1$s isn\'t compatible with your Android version. To continue using your device, please uninstall %1$s updates or disable %1$s as a system gesture provider.</string>
     <string name="translucent_background">Translucent background</string>

--- a/lawnchair/res/values-az/strings.xml
+++ b/lawnchair/res/values-az/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI köməkçisi
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-b+sr+Latn/strings.xml
+++ b/lawnchair/res/values-b+sr+Latn/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, Аи асистент
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@
     <string name="time_weeks_ago">%dw</string>
     <string name="time_months_ago">%dmo</string>
     <string name="time_years_ago">%dy</string>
-    <string name="managed_by_lawnchair">Upravlja Lawnchair</string>
+    <string name="managed_by_lawnchair">Upravlja Аи асистент</string>
     <!-- When mentioning settings UI -->
     <string name="smartspace_preferences">Podešavanja</string>
     <string name="settings_button_text">Podešavanja početnog ekrana</string>
@@ -69,7 +69,7 @@
     <string name="title_change_settings">Promenite podešavanja</string>
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout Аи асистент
 
     -->
     <string name="others_category_label">Others</string>
@@ -114,7 +114,7 @@
     <string name="folders_filter_duplicates">Only show unique apps</string>
     <string name="my_folder_label">My folder</string>
     <!-- A11y description -->
-    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, Lawnchair uses the performGlobalAction Accessibility service.</string>
+    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, Аи асистент requires accessibility access.\n\nАи асистент doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Аи асистент discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, Аи асистент uses the performGlobalAction Accessibility service.</string>
     <string name="x_with_y_count">%1$s (%2$d)</string>
     <string name="x_by_y">%1$d x %2$d</string>
     <string name="x_and_y">%1$s i %2$s</string>
@@ -143,7 +143,7 @@
     <string name="quickstep_description">Dugme „Obriši sve”, zaobljenost uglova</string>
     <string name="about_label">O aplikaciji</string>
     <string name="app_info_drop_target_label">Informacije o aplikaciji</string>
-    <string name="debug_restart_launcher">Restartuj Lawnchair</string>
+    <string name="debug_restart_launcher">Restartuj Аи асистент</string>
     <string name="experimental_features_label">Eksperimentalne funkcije</string>
     <!-- Experimental features -->
     <string name="font_picker_label">Prilagođavanje fonta</string>
@@ -171,7 +171,7 @@
     Notifications
 
     -->
-    <string name="set_default_launcher_tip">Da biste pristupali prečicama i drugim funkcijama, podesite Lawnchair kao podrazumevani pokretač</string>
+    <string name="set_default_launcher_tip">Da biste pristupali prečicama i drugim funkcijama, podesite Аи асистент kao podrazumevani pokretač</string>
     <string name="notification_dots">Tačke za obaveštenja</string>
     <string name="show_notification_count">Prikazuj broj obaveštenja</string>
     <string name="notification_dots_color">Boja tačke za obaveštenja</string>
@@ -344,7 +344,7 @@
     <string name="event_provider_missing_notification_dots">Da biste koristili „<xliff:g example="My Provider" id="providerName">%1$s</xliff:g>”, uključite tačke za obaveštenja.</string>
     <!-- Toggle button for enabling Smartspace -->
     <string name="smartspace_widget_toggle_label">Prikaži na početnom ekranu</string>
-    <string name="smartspace_widget_toggle_description">„Kratak pregled” možete da dodate ručno postavljanjem vidžeta „Lawnchair”</string>
+    <string name="smartspace_widget_toggle_description">„Kratak pregled” možete da dodate ručno postavljanjem vidžeta „Аи асистент”</string>
     <!-- List of available providers -->
     <string name="smartspace_mode_label">Dobavljač za „Kratak pregled”</string>
     <string name="smartspace_mode_google">Google</string>
@@ -415,18 +415,18 @@
     <string name="gesture_handler_open_assistant">Open assistant</string>
     <string name="pick_app_for_gesture">Izaberite aplikaciju</string>
     <string name="dt2s_admin_hint_title">Potrebne su administratorske dozvole</string>
-    <string name="dt2s_admin_hint">Da biste koristili funkciju „Dodirnite dvaput za stanje spavanja”, podesite Lawnchair kao administrator uređaja. U podešavanjima dodirnite „Aktiviraj ovu aplikaciju za administratora uređaja”.</string>
+    <string name="dt2s_admin_hint">Da biste koristili funkciju „Dodirnite dvaput za stanje spavanja”, podesite Аи асистент kao administrator uređaja. U podešavanjima dodirnite „Aktiviraj ovu aplikaciju za administratora uređaja”.</string>
     <string name="dt2s_admin_warning">Funkcija „Dodirnite dvaput za stanje spavanja” će biti isključena</string>
     <string name="d2ts_recents_a11y_hint_title">Uključi uslugu pristupačnosti</string>
-    <string name="dt2s_a11y_hint">Da biste koristili funkciju „Dodirnite dvaput za stanje spavanja”, uključite Lawnchair-ovu uslugu pristupačnosti. Dodirnite „Otvori podešavanja”, izaberite „Lawnchair” i uključite „Koristi Lawnchair”.\n\nOva dozvola je osetljiva jer omogućava nadgledanje drugih aplikacija, ali je Lawnchair ne koristi u te svrhe.</string>
+    <string name="dt2s_a11y_hint">Da biste koristili funkciju „Dodirnite dvaput za stanje spavanja”, uključite Аи асистент-ovu uslugu pristupačnosti. Dodirnite „Otvori podešavanja”, izaberite „Аи асистент” i uključite „Koristi Аи асистент”.\n\nOva dozvola je osetljiva jer omogućava nadgledanje drugih aplikacija, ali je Аи асистент ne koristi u te svrhe.</string>
     <string name="dt2s_recents_warning_open_settings">Otvori podešavanja</string>
-    <string name="recents_a11y_hint">To use Open Recents screen, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="recents_a11y_hint">To use Open Recents screen, turn on the Аи асистент accessibility service. Tap \"Open settings\", select \"Аи асистент\" and turn on \"Use Аи асистент.\"\n\nАи асистент uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Аи асистент is not configured for that functionality and receives no events.</string>
     <!--
 
     Bug reporting
 
     -->
-    <string name="lawnchair_bug_report">Izveštaj o grešci u Lawnchairu</string>
+    <string name="lawnchair_bug_report">Izveštaj o grešci u Аи асистентu</string>
     <string name="crash_report_notif_title">%1$s je otkazao</string>
     <string name="action_upload_crash_report">Otpremi evidenciju o otkazivanju</string>
     <string name="action_upload_error">Otpremanje nije uspelo</string>
@@ -519,7 +519,7 @@
     <!-- Search providers -->
     <string name="search_provider_app_search">Pretraga aplikacija</string>
     <string name="search_provider_custom">Prilagođena</string>
-    <string name="search_provider_sponsored_description">%1$s i Lawnchair imaju ugovor o podeli prihoda.\n\nPretraživanjem pomoću usluge %1$s podržavate Lawnchair.</string>
+    <string name="search_provider_sponsored_description">%1$s i Аи асистент imaju ugovor o podeli prihoda.\n\nPretraživanjem pomoću usluge %1$s podržavate Аи асистент.</string>
     <string name="app_label">Aplikacija</string>
     <string name="website_label">Sajt</string>
     <string name="qsb_search_provider_app_required">Potrebna je aplikacija</string>
@@ -553,7 +553,7 @@
     <string name="max_folder_columns">Maksimalan broj kolona u folderu</string>
     <string name="max_folder_rows">Maksimalan broj redova u folderu</string>
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">These settings will be ignored as Lawnchair isn\'t set as the Recents screen provider</string>
+    <string name="quickswitch_ignored_warning">These settings will be ignored as Аи асистент isn\'t set as the Recents screen provider</string>
     <string name="quickstep_incompatible">Nekompatibilna sistemska integracija</string>
     <string name="quickstep_incompatible_description">Uređaj je podešen da koristi sistemske pokrete (poznate kao Quickstep), koje pruža %1$s, ali ova verzija %1$sa nije kompatibilna sa vašom verzijom Androida. Da biste nastavili da koristite uređaj, deinstalirajte ažuriranja %1$sa ili onemogućite %1$s kao dobavljača sistemskih pokreta.</string>
     <string name="translucent_background">Poluprozirna pozadina</string>

--- a/lawnchair/res/values-be/strings.xml
+++ b/lawnchair/res/values-be/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI памочнік
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-bg/strings.xml
+++ b/lawnchair/res/values-bg/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI асистент
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-bn-rBD/strings.xml
+++ b/lawnchair/res/values-bn-rBD/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, এআই সহকারী
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@
     <string name="time_weeks_ago">%dw</string>
     <string name="time_months_ago">%dmo</string>
     <string name="time_years_ago">%dy</string>
-    <string name="managed_by_lawnchair">Lawnchair দ্বারা পরিচালিত করা হবে</string>
+    <string name="managed_by_lawnchair">এআই সহকারী দ্বারা পরিচালিত করা হবে</string>
     <!-- When mentioning settings UI -->
     <string name="smartspace_preferences">পছন্দ-সমুহ</string>
     <string name="settings_button_text">হোম সেটিংস</string>
@@ -69,7 +69,7 @@
     <string name="title_change_settings">সেটিংস পরিবর্তন করুন</string>
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout এআই সহকারী
 
     -->
     <string name="others_category_label">অন্যান্য</string>
@@ -114,7 +114,7 @@
     <string name="folders_filter_duplicates">শুধুমাত্র অনন্য অ্যাপগুলি দেখান</string>
     <string name="my_folder_label">আমার ফোল্ডার</string>
     <!-- A11y description -->
-    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, Lawnchair uses the performGlobalAction Accessibility service.</string>
+    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, এআই সহকারী requires accessibility access.\n\nএআই সহকারী doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. এআই সহকারী discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, এআই সহকারী uses the performGlobalAction Accessibility service.</string>
     <string name="x_with_y_count">%1$s (%2$d)</string>
     <string name="x_by_y">%1$d x %2$d</string>
     <string name="x_and_y">%1$s &amp; %2$s</string>
@@ -171,7 +171,7 @@
     Notifications
 
     -->
-    <string name="set_default_launcher_tip">To access shortcuts and additional features, set Lawnchair as your default launcher</string>
+    <string name="set_default_launcher_tip">To access shortcuts and additional features, set এআই সহকারী as your default launcher</string>
     <string name="notification_dots">Notification dots</string>
     <string name="show_notification_count">Show notification counter</string>
     <string name="notification_dots_color">Notification dot color</string>
@@ -344,7 +344,7 @@
     <string name="event_provider_missing_notification_dots">To use <xliff:g example="My Provider" id="providerName">%1$s</xliff:g>, turn on Notification Dots.</string>
     <!-- Toggle button for enabling Smartspace -->
     <string name="smartspace_widget_toggle_label">Show on home screen</string>
-    <string name="smartspace_widget_toggle_description">At a Glance can be manually added to the home screen by placing the Lawnchair widget</string>
+    <string name="smartspace_widget_toggle_description">At a Glance can be manually added to the home screen by placing the এআই সহকারী widget</string>
     <!-- List of available providers -->
     <string name="smartspace_mode_label">At a Glance provider</string>
     <string name="smartspace_mode_google">Google</string>
@@ -415,18 +415,18 @@
     <string name="gesture_handler_open_assistant">Open assistant</string>
     <string name="pick_app_for_gesture">Pick app</string>
     <string name="dt2s_admin_hint_title">Admin permissions required</string>
-    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set Lawnchair as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
+    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set এআই সহকারী as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
     <string name="dt2s_admin_warning">ডাবল-ট্যাপে লক হওয়া বন্ধ হয়ে যাবে.</string>
     <string name="d2ts_recents_a11y_hint_title">Turn on accessibility service</string>
-    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the এআই সহকারী accessibility service. Tap \"Open settings\", select \"এআই সহকারী\" and turn on \"Use এআই সহকারী.\"\n\nএআই সহকারী uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, এআই সহকারী is not configured for that functionality and receives no events.</string>
     <string name="dt2s_recents_warning_open_settings">Open settings</string>
-    <string name="recents_a11y_hint">To use Open Recents screen, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="recents_a11y_hint">To use Open Recents screen, turn on the এআই সহকারী accessibility service. Tap \"Open settings\", select \"এআই সহকারী\" and turn on \"Use এআই সহকারী.\"\n\nএআই সহকারী uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, এআই সহকারী is not configured for that functionality and receives no events.</string>
     <!--
 
     Bug reporting
 
     -->
-    <string name="lawnchair_bug_report">Lawnchair bug report</string>
+    <string name="lawnchair_bug_report">এআই সহকারী bug report</string>
     <string name="crash_report_notif_title">%1$s crashed</string>
     <string name="action_upload_crash_report">Upload crash log</string>
     <string name="action_upload_error">আপলোড ব্যর্থ হয়েছে</string>
@@ -519,7 +519,7 @@
     <!-- Search providers -->
     <string name="search_provider_app_search">App search</string>
     <string name="search_provider_custom">পছন্দসই</string>
-    <string name="search_provider_sponsored_description">%1$s and Lawnchair have a revenue share agreement.\n\nSearching with %1$s helps support Lawnchair.</string>
+    <string name="search_provider_sponsored_description">%1$s and এআই সহকারী have a revenue share agreement.\n\nSearching with %1$s helps support এআই সহকারী.</string>
     <string name="app_label">App</string>
     <string name="website_label">Website</string>
     <string name="qsb_search_provider_app_required">App required</string>
@@ -552,7 +552,7 @@
     <string name="max_folder_columns">Maximum folder columns</string>
     <string name="max_folder_rows">Maximum folder rows</string>
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">These settings will be ignored as Lawnchair isn\'t set as the Recents screen provider</string>
+    <string name="quickswitch_ignored_warning">These settings will be ignored as এআই সহকারী isn\'t set as the Recents screen provider</string>
     <string name="quickstep_incompatible">Incompatible system integration</string>
     <string name="quickstep_incompatible_description">Your device is configured to have system gestures (known as Quickstep) provided by %1$s, but this version of %1$s isn\'t compatible with your Android version. To continue using your device, please uninstall %1$s updates or disable %1$s as a system gesture provider.</string>
     <string name="translucent_background">Translucent background</string>

--- a/lawnchair/res/values-bn/strings.xml
+++ b/lawnchair/res/values-bn/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, এআই সহকারী
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-bs-rBA/strings.xml
+++ b/lawnchair/res/values-bs-rBA/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI asistent
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@
     <string name="time_weeks_ago">%dw</string>
     <string name="time_months_ago">%dmo</string>
     <string name="time_years_ago">%dy</string>
-    <string name="managed_by_lawnchair">Upravljano putem Lawnchair</string>
+    <string name="managed_by_lawnchair">Upravljano putem AI asistent</string>
     <!-- When mentioning settings UI -->
     <string name="smartspace_preferences">Preferencije</string>
     <string name="settings_button_text">Postavke početnog ekrana</string>
@@ -69,7 +69,7 @@
     <string name="title_change_settings">Promijeni postavke</string>
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout AI asistent
 
     -->
     <string name="others_category_label">Ostalo</string>
@@ -114,7 +114,7 @@
     <string name="folders_filter_duplicates">Prikaži samo jedinstvene aplikacije</string>
     <string name="my_folder_label">Moja fascikla</string>
     <!-- A11y description -->
-    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, Lawnchair uses the performGlobalAction Accessibility service.</string>
+    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, AI asistent requires accessibility access.\n\nAI asistent doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. AI asistent discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, AI asistent uses the performGlobalAction Accessibility service.</string>
     <string name="x_with_y_count">%1$s(%2$d)</string>
     <string name="x_by_y">%1$dx%2$d</string>
     <string name="x_and_y">%1$s&amp;%2$s</string>
@@ -143,7 +143,7 @@
     <string name="quickstep_description">Clear All button, corner radius</string>
     <string name="about_label">About</string>
     <string name="app_info_drop_target_label">App info</string>
-    <string name="debug_restart_launcher">Restart Lawnchair</string>
+    <string name="debug_restart_launcher">Restart AI asistent</string>
     <string name="experimental_features_label">Experimental features</string>
     <!-- Experimental features -->
     <string name="font_picker_label">Font customization</string>
@@ -171,7 +171,7 @@
     Notifications
 
     -->
-    <string name="set_default_launcher_tip">Da biste pristupili prečicama i dodatnim funkcijama, postavite Lawnchair kao zadani pokretač</string>
+    <string name="set_default_launcher_tip">Da biste pristupili prečicama i dodatnim funkcijama, postavite AI asistent kao zadani pokretač</string>
     <string name="notification_dots">Tačke obavještenja</string>
     <string name="show_notification_count">Prikaži brojač obavještenja</string>
     <string name="notification_dots_color">Boja tačke obavještenja</string>
@@ -344,7 +344,7 @@
     <string name="event_provider_missing_notification_dots">To use <xliff:g example="My Provider" id="providerName">%1$s</xliff:g>, turn on Notification Dots.</string>
     <!-- Toggle button for enabling Smartspace -->
     <string name="smartspace_widget_toggle_label">Show on home screen</string>
-    <string name="smartspace_widget_toggle_description">At a Glance can be manually added to the home screen by placing the Lawnchair widget</string>
+    <string name="smartspace_widget_toggle_description">At a Glance can be manually added to the home screen by placing the AI asistent widget</string>
     <!-- List of available providers -->
     <string name="smartspace_mode_label">At a Glance provider</string>
     <string name="smartspace_mode_google">Google</string>
@@ -415,18 +415,18 @@
     <string name="gesture_handler_open_assistant">Open assistant</string>
     <string name="pick_app_for_gesture">Pick app</string>
     <string name="dt2s_admin_hint_title">Admin permissions required</string>
-    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set Lawnchair as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
+    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set AI asistent as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
     <string name="dt2s_admin_warning">Double-Tap to Sleep will be turned off.</string>
     <string name="d2ts_recents_a11y_hint_title">Turn on accessibility service</string>
-    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the AI asistent accessibility service. Tap \"Open settings\", select \"AI asistent\" and turn on \"Use AI asistent.\"\n\nAI asistent uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, AI asistent is not configured for that functionality and receives no events.</string>
     <string name="dt2s_recents_warning_open_settings">Open settings</string>
-    <string name="recents_a11y_hint">To use Open Recents screen, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="recents_a11y_hint">To use Open Recents screen, turn on the AI asistent accessibility service. Tap \"Open settings\", select \"AI asistent\" and turn on \"Use AI asistent.\"\n\nAI asistent uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, AI asistent is not configured for that functionality and receives no events.</string>
     <!--
 
     Bug reporting
 
     -->
-    <string name="lawnchair_bug_report">Lawnchair bug report</string>
+    <string name="lawnchair_bug_report">AI asistent bug report</string>
     <string name="crash_report_notif_title">%1$s crashed</string>
     <string name="action_upload_crash_report">Upload crash log</string>
     <string name="action_upload_error">Upload failed</string>
@@ -519,7 +519,7 @@
     <!-- Search providers -->
     <string name="search_provider_app_search">App search</string>
     <string name="search_provider_custom">Prilagođeno</string>
-    <string name="search_provider_sponsored_description">%1$s and Lawnchair have a revenue share agreement.\n\nSearching with %1$s helps support Lawnchair.</string>
+    <string name="search_provider_sponsored_description">%1$s and AI asistent have a revenue share agreement.\n\nSearching with %1$s helps support AI asistent.</string>
     <string name="app_label">App</string>
     <string name="website_label">Website</string>
     <string name="qsb_search_provider_app_required">App required</string>
@@ -553,7 +553,7 @@
     <string name="max_folder_columns">Maximum folder columns</string>
     <string name="max_folder_rows">Maximum folder rows</string>
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">These settings will be ignored as Lawnchair isn\'t set as the Recents screen provider</string>
+    <string name="quickswitch_ignored_warning">These settings will be ignored as AI asistent isn\'t set as the Recents screen provider</string>
     <string name="quickstep_incompatible">Incompatible system integration</string>
     <string name="quickstep_incompatible_description">Your device is configured to have system gestures (known as Quickstep) provided by %1$s, but this version of %1$s isn\'t compatible with your Android version. To continue using your device, please uninstall %1$s updates or disable %1$s as a system gesture provider.</string>
     <string name="translucent_background">Translucent background</string>

--- a/lawnchair/res/values-bs/strings.xml
+++ b/lawnchair/res/values-bs/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI asistent
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-ca-rES/strings.xml
+++ b/lawnchair/res/values-ca-rES/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, Assistent AI
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@
     <string name="time_weeks_ago">%dw</string>
     <string name="time_months_ago">%dmo</string>
     <string name="time_years_ago">%dy</string>
-    <string name="managed_by_lawnchair">Gestionat per Lawnchair</string>
+    <string name="managed_by_lawnchair">Gestionat per Assistent AI</string>
     <!-- When mentioning settings UI -->
     <string name="smartspace_preferences">Preferències</string>
     <string name="settings_button_text">Configuració d\'inici</string>
@@ -69,7 +69,7 @@
     <string name="title_change_settings">Canvia la configuració</string>
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout Assistent AI
 
     -->
     <string name="others_category_label">Others</string>
@@ -114,7 +114,7 @@
     <string name="folders_filter_duplicates">Only show unique apps</string>
     <string name="my_folder_label">My folder</string>
     <!-- A11y description -->
-    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, Lawnchair uses the performGlobalAction Accessibility service.</string>
+    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, Assistent AI requires accessibility access.\n\nAssistent AI doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Assistent AI discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, Assistent AI uses the performGlobalAction Accessibility service.</string>
     <string name="x_with_y_count">%1$s (%2$d)</string>
     <string name="x_by_y">%1$d x %2$d</string>
     <string name="x_and_y">%1$s &amp; %2$s</string>
@@ -143,7 +143,7 @@
     <string name="quickstep_description">Clear All button, corner radius</string>
     <string name="about_label">Quant a</string>
     <string name="app_info_drop_target_label">App info</string>
-    <string name="debug_restart_launcher">Reinicia Lawnchair</string>
+    <string name="debug_restart_launcher">Reinicia Assistent AI</string>
     <string name="experimental_features_label">Experimental features</string>
     <!-- Experimental features -->
     <string name="font_picker_label">Font customization</string>
@@ -171,7 +171,7 @@
     Notifications
 
     -->
-    <string name="set_default_launcher_tip">To access shortcuts and additional features, set Lawnchair as your default launcher</string>
+    <string name="set_default_launcher_tip">To access shortcuts and additional features, set Assistent AI as your default launcher</string>
     <string name="notification_dots">Notification dots</string>
     <string name="show_notification_count">Show notification counter</string>
     <string name="notification_dots_color">Notification dot color</string>
@@ -344,7 +344,7 @@
     <string name="event_provider_missing_notification_dots">To use <xliff:g example="My Provider" id="providerName">%1$s</xliff:g>, turn on Notification Dots.</string>
     <!-- Toggle button for enabling Smartspace -->
     <string name="smartspace_widget_toggle_label">Show on home screen</string>
-    <string name="smartspace_widget_toggle_description">At a Glance can be manually added to the home screen by placing the Lawnchair widget</string>
+    <string name="smartspace_widget_toggle_description">At a Glance can be manually added to the home screen by placing the Assistent AI widget</string>
     <!-- List of available providers -->
     <string name="smartspace_mode_label">At a Glance provider</string>
     <string name="smartspace_mode_google">Google</string>
@@ -415,18 +415,18 @@
     <string name="gesture_handler_open_assistant">Open assistant</string>
     <string name="pick_app_for_gesture">Pick app</string>
     <string name="dt2s_admin_hint_title">Admin permissions required</string>
-    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set Lawnchair as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
+    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set Assistent AI as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
     <string name="dt2s_admin_warning">\"Toca dos cops per apagar la pantalla\" s\'apagarà.</string>
     <string name="d2ts_recents_a11y_hint_title">Turn on accessibility service</string>
-    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the Assistent AI accessibility service. Tap \"Open settings\", select \"Assistent AI\" and turn on \"Use Assistent AI.\"\n\nAssistent AI uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Assistent AI is not configured for that functionality and receives no events.</string>
     <string name="dt2s_recents_warning_open_settings">Open settings</string>
-    <string name="recents_a11y_hint">To use Open Recents screen, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="recents_a11y_hint">To use Open Recents screen, turn on the Assistent AI accessibility service. Tap \"Open settings\", select \"Assistent AI\" and turn on \"Use Assistent AI.\"\n\nAssistent AI uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Assistent AI is not configured for that functionality and receives no events.</string>
     <!--
 
     Bug reporting
 
     -->
-    <string name="lawnchair_bug_report">Lawnchair bug report</string>
+    <string name="lawnchair_bug_report">Assistent AI bug report</string>
     <string name="crash_report_notif_title">%1$s crashed</string>
     <string name="action_upload_crash_report">Upload crash log</string>
     <string name="action_upload_error">La pujada ha fallat</string>
@@ -519,7 +519,7 @@
     <!-- Search providers -->
     <string name="search_provider_app_search">App search</string>
     <string name="search_provider_custom">Personalitzat</string>
-    <string name="search_provider_sponsored_description">%1$s and Lawnchair have a revenue share agreement.\n\nSearching with %1$s helps support Lawnchair.</string>
+    <string name="search_provider_sponsored_description">%1$s and Assistent AI have a revenue share agreement.\n\nSearching with %1$s helps support Assistent AI.</string>
     <string name="app_label">Aplicació</string>
     <string name="website_label">Lloc web</string>
     <string name="qsb_search_provider_app_required">App required</string>
@@ -552,7 +552,7 @@
     <string name="max_folder_columns">Maximum folder columns</string>
     <string name="max_folder_rows">Maximum folder rows</string>
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">These settings will be ignored as Lawnchair isn\'t set as the Recents screen provider</string>
+    <string name="quickswitch_ignored_warning">These settings will be ignored as Assistent AI isn\'t set as the Recents screen provider</string>
     <string name="quickstep_incompatible">Incompatible system integration</string>
     <string name="quickstep_incompatible_description">Your device is configured to have system gestures (known as Quickstep) provided by %1$s, but this version of %1$s isn\'t compatible with your Android version. To continue using your device, please uninstall %1$s updates or disable %1$s as a system gesture provider.</string>
     <string name="translucent_background">Translucent background</string>

--- a/lawnchair/res/values-ca/strings.xml
+++ b/lawnchair/res/values-ca/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, Assistent AI
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-cs-rCZ/strings.xml
+++ b/lawnchair/res/values-cs-rCZ/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AIS asistent
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@
     <string name="time_weeks_ago">%dw</string>
     <string name="time_months_ago">%dmo</string>
     <string name="time_years_ago">%dy</string>
-    <string name="managed_by_lawnchair">Spravováno aplikací Lawnchair</string>
+    <string name="managed_by_lawnchair">Spravováno aplikací AIS asistent</string>
     <!-- When mentioning settings UI -->
     <string name="smartspace_preferences">Předvolby</string>
     <string name="settings_button_text">Nastavení domovské obrazovky</string>
@@ -69,7 +69,7 @@
     <string name="title_change_settings">Změnit nastavení</string>
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout AIS asistent
 
     -->
     <string name="others_category_label">Ostatní</string>
@@ -114,7 +114,7 @@
     <string name="folders_filter_duplicates">Zobrazit pouze unikátní aplikace</string>
     <string name="my_folder_label">Moje složka</string>
     <!-- A11y description -->
-    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, Lawnchair uses the performGlobalAction Accessibility service.</string>
+    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, AIS asistent requires accessibility access.\n\nAIS asistent doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. AIS asistent discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, AIS asistent uses the performGlobalAction Accessibility service.</string>
     <string name="x_with_y_count">%1$s (%2$d)</string>
     <string name="x_by_y">%1$d x %2$d</string>
     <string name="x_and_y">%1$s &amp; %2$s</string>
@@ -143,7 +143,7 @@
     <string name="quickstep_description">Tlačítko „Vymazat vše“, Poloměr rohů</string>
     <string name="about_label">O aplikaci</string>
     <string name="app_info_drop_target_label">Informace o aplikaci</string>
-    <string name="debug_restart_launcher">Restartovat Lawnchair</string>
+    <string name="debug_restart_launcher">Restartovat AIS asistent</string>
     <string name="experimental_features_label">Experimentální funkce</string>
     <!-- Experimental features -->
     <string name="font_picker_label">Přizbpůsobení fontu</string>
@@ -171,7 +171,7 @@
     Notifications
 
     -->
-    <string name="set_default_launcher_tip">Pro přístup ke zkratkám a dalším funkcím nastavte Lawnchair jako výchozí spouštěč</string>
+    <string name="set_default_launcher_tip">Pro přístup ke zkratkám a dalším funkcím nastavte AIS asistent jako výchozí spouštěč</string>
     <string name="notification_dots">Notifikační tečky</string>
     <string name="show_notification_count">Zobrazit počet oznámení</string>
     <string name="notification_dots_color">Barva oznamovací tečky</string>
@@ -344,7 +344,7 @@
     <string name="event_provider_missing_notification_dots">To use <xliff:g example="My Provider" id="providerName">%1$s</xliff:g>, turn on Notification Dots.</string>
     <!-- Toggle button for enabling Smartspace -->
     <string name="smartspace_widget_toggle_label">Zobrazit na domovské obrazovce</string>
-    <string name="smartspace_widget_toggle_description">At a Glanc je možné přidat ručně umístěním widgetu \"Lawnchair\"</string>
+    <string name="smartspace_widget_toggle_description">At a Glanc je možné přidat ručně umístěním widgetu \"AIS asistent\"</string>
     <!-- List of available providers -->
     <string name="smartspace_mode_label">At a Glance provider</string>
     <string name="smartspace_mode_google">Google</string>
@@ -415,18 +415,18 @@
     <string name="gesture_handler_open_assistant">Otevřít asistenta</string>
     <string name="pick_app_for_gesture">Vybrat aplikaci</string>
     <string name="dt2s_admin_hint_title">Vyžaduje oprávnění administrátora</string>
-    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set Lawnchair as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
+    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set AIS asistent as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
     <string name="dt2s_admin_warning">Uspání dvojitým poklepáním bude vypnuto.</string>
     <string name="d2ts_recents_a11y_hint_title">Zapnout službu usnadnění</string>
-    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the AIS asistent accessibility service. Tap \"Open settings\", select \"AIS asistent\" and turn on \"Use AIS asistent.\"\n\nAIS asistent uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, AIS asistent is not configured for that functionality and receives no events.</string>
     <string name="dt2s_recents_warning_open_settings">Otevřít nastavení</string>
-    <string name="recents_a11y_hint">To use Open Recents screen, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="recents_a11y_hint">To use Open Recents screen, turn on the AIS asistent accessibility service. Tap \"Open settings\", select \"AIS asistent\" and turn on \"Use AIS asistent.\"\n\nAIS asistent uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, AIS asistent is not configured for that functionality and receives no events.</string>
     <!--
 
     Bug reporting
 
     -->
-    <string name="lawnchair_bug_report">Hlášení o chybě v Lawnchair</string>
+    <string name="lawnchair_bug_report">Hlášení o chybě v AIS asistent</string>
     <string name="crash_report_notif_title">%1$s přestal fungovat</string>
     <string name="action_upload_crash_report">Nahrát protokol pádů</string>
     <string name="action_upload_error">Nahrávání selhalo</string>
@@ -519,7 +519,7 @@
     <!-- Search providers -->
     <string name="search_provider_app_search">Hledání aplikací</string>
     <string name="search_provider_custom">Vlastní</string>
-    <string name="search_provider_sponsored_description">%1$s a Lawnchair má smlouvu o sdílení příjmů.\n\nVyhledávání pomocí %1$s pomáhá podpořit Lawnchair.</string>
+    <string name="search_provider_sponsored_description">%1$s a AIS asistent má smlouvu o sdílení příjmů.\n\nVyhledávání pomocí %1$s pomáhá podpořit AIS asistent.</string>
     <string name="app_label">Aplikace</string>
     <string name="website_label">Web</string>
     <string name="qsb_search_provider_app_required">Aplikace je vyžadována</string>
@@ -554,7 +554,7 @@
     <string name="max_folder_columns">Maximální počet sloupců složky</string>
     <string name="max_folder_rows">Maximální počet řádků složky</string>
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">These settings will be ignored as Lawnchair isn\'t set as the Recents screen provider</string>
+    <string name="quickswitch_ignored_warning">These settings will be ignored as AIS asistent isn\'t set as the Recents screen provider</string>
     <string name="quickstep_incompatible">Nekompatibilní systémová integrace</string>
     <string name="quickstep_incompatible_description">Your device is configured to have system gestures (known as Quickstep) provided by %1$s, but this version of %1$s isn\'t compatible with your Android version. To continue using your device, please uninstall %1$s updates or disable %1$s as a system gesture provider.</string>
     <string name="translucent_background">Průsvitné pozadí</string>

--- a/lawnchair/res/values-cs/strings.xml
+++ b/lawnchair/res/values-cs/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AIS asistent
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-da-rDK/strings.xml
+++ b/lawnchair/res/values-da-rDK/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI -assistent
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@
     <string name="time_weeks_ago">%dw</string>
     <string name="time_months_ago">%dmo</string>
     <string name="time_years_ago">%dy</string>
-    <string name="managed_by_lawnchair">Administreret af Lawnchair</string>
+    <string name="managed_by_lawnchair">Administreret af AI -assistent</string>
     <!-- When mentioning settings UI -->
     <string name="smartspace_preferences">Præferencer</string>
     <string name="settings_button_text">Indst. for startskærm</string>
@@ -69,7 +69,7 @@
     <string name="title_change_settings">Ændr indstillinger</string>
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout AI -assistent
 
     -->
     <string name="others_category_label">Others</string>
@@ -114,7 +114,7 @@
     <string name="folders_filter_duplicates">Only show unique apps</string>
     <string name="my_folder_label">My folder</string>
     <!-- A11y description -->
-    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, Lawnchair uses the performGlobalAction Accessibility service.</string>
+    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, AI -assistent requires accessibility access.\n\nAI -assistent doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. AI -assistent discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, AI -assistent uses the performGlobalAction Accessibility service.</string>
     <string name="x_with_y_count">%1$s (%2$d)</string>
     <string name="x_by_y">%1$d × %2$d</string>
     <string name="x_and_y">%1$s &amp; %2$s</string>
@@ -143,7 +143,7 @@
     <string name="quickstep_description">Ryd alle-knap, hjørneradius</string>
     <string name="about_label">Om</string>
     <string name="app_info_drop_target_label">App info</string>
-    <string name="debug_restart_launcher">Genstart Lawnchair</string>
+    <string name="debug_restart_launcher">Genstart AI -assistent</string>
     <string name="experimental_features_label">Eksperimentelle funktioner</string>
     <!-- Experimental features -->
     <string name="font_picker_label">Tilpasning af skrifttype</string>
@@ -171,7 +171,7 @@
     Notifications
 
     -->
-    <string name="set_default_launcher_tip">To access shortcuts and additional features, set Lawnchair as your default launcher</string>
+    <string name="set_default_launcher_tip">To access shortcuts and additional features, set AI -assistent as your default launcher</string>
     <string name="notification_dots">Notification dots</string>
     <string name="show_notification_count">Show notification counter</string>
     <string name="notification_dots_color">Notification dot color</string>
@@ -344,7 +344,7 @@
     <string name="event_provider_missing_notification_dots">To use <xliff:g example="My Provider" id="providerName">%1$s</xliff:g>, turn on Notification Dots.</string>
     <!-- Toggle button for enabling Smartspace -->
     <string name="smartspace_widget_toggle_label">Show on home screen</string>
-    <string name="smartspace_widget_toggle_description">At a Glance can be manually added to the home screen by placing the Lawnchair widget</string>
+    <string name="smartspace_widget_toggle_description">At a Glance can be manually added to the home screen by placing the AI -assistent widget</string>
     <!-- List of available providers -->
     <string name="smartspace_mode_label">At a Glance provider</string>
     <string name="smartspace_mode_google">Google</string>
@@ -415,18 +415,18 @@
     <string name="gesture_handler_open_assistant">Open assistant</string>
     <string name="pick_app_for_gesture">Pick app</string>
     <string name="dt2s_admin_hint_title">Admin permissions required</string>
-    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set Lawnchair as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
+    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set AI -assistent as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
     <string name="dt2s_admin_warning">Dobbelttryk for at sove vil blive slået fra.</string>
     <string name="d2ts_recents_a11y_hint_title">Turn on accessibility service</string>
-    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the AI -assistent accessibility service. Tap \"Open settings\", select \"AI -assistent\" and turn on \"Use AI -assistent.\"\n\nAI -assistent uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, AI -assistent is not configured for that functionality and receives no events.</string>
     <string name="dt2s_recents_warning_open_settings">Open settings</string>
-    <string name="recents_a11y_hint">To use Open Recents screen, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="recents_a11y_hint">To use Open Recents screen, turn on the AI -assistent accessibility service. Tap \"Open settings\", select \"AI -assistent\" and turn on \"Use AI -assistent.\"\n\nAI -assistent uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, AI -assistent is not configured for that functionality and receives no events.</string>
     <!--
 
     Bug reporting
 
     -->
-    <string name="lawnchair_bug_report">Lawnchair bug report</string>
+    <string name="lawnchair_bug_report">AI -assistent bug report</string>
     <string name="crash_report_notif_title">%1$s crashed</string>
     <string name="action_upload_crash_report">Upload crash log</string>
     <string name="action_upload_error">Upload mislykkedes</string>
@@ -519,7 +519,7 @@
     <!-- Search providers -->
     <string name="search_provider_app_search">App search</string>
     <string name="search_provider_custom">Brugerdefineret</string>
-    <string name="search_provider_sponsored_description">%1$s and Lawnchair have a revenue share agreement.\n\nSearching with %1$s helps support Lawnchair.</string>
+    <string name="search_provider_sponsored_description">%1$s and AI -assistent have a revenue share agreement.\n\nSearching with %1$s helps support AI -assistent.</string>
     <string name="app_label">App</string>
     <string name="website_label">Hjemmside</string>
     <string name="qsb_search_provider_app_required">App påkrævet</string>
@@ -552,7 +552,7 @@
     <string name="max_folder_columns">Maximum folder columns</string>
     <string name="max_folder_rows">Maximum folder rows</string>
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">These settings will be ignored as Lawnchair isn\'t set as the Recents screen provider</string>
+    <string name="quickswitch_ignored_warning">These settings will be ignored as AI -assistent isn\'t set as the Recents screen provider</string>
     <string name="quickstep_incompatible">Incompatible system integration</string>
     <string name="quickstep_incompatible_description">Your device is configured to have system gestures (known as Quickstep) provided by %1$s, but this version of %1$s isn\'t compatible with your Android version. To continue using your device, please uninstall %1$s updates or disable %1$s as a system gesture provider.</string>
     <string name="translucent_background">Translucent background</string>

--- a/lawnchair/res/values-da/strings.xml
+++ b/lawnchair/res/values-da/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI -assistent
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-de-rDE/strings.xml
+++ b/lawnchair/res/values-de-rDE/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI -Assistent
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@
     <string name="time_weeks_ago">%dW.</string>
     <string name="time_months_ago">%dMon.</string>
     <string name="time_years_ago">%dJ.</string>
-    <string name="managed_by_lawnchair">Von Lawnchair verwaltet</string>
+    <string name="managed_by_lawnchair">Von AI -Assistent verwaltet</string>
     <!-- When mentioning settings UI -->
     <string name="smartspace_preferences">Voreinstellungen</string>
     <string name="settings_button_text">Home-Einstellungen</string>
@@ -69,7 +69,7 @@
     <string name="title_change_settings">Einstellungen ändern</string>
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout AI -Assistent
 
     -->
     <string name="others_category_label">Andere</string>
@@ -114,7 +114,7 @@
     <string name="folders_filter_duplicates">Nur Apps, die keine Duplikate sind, zeigen</string>
     <string name="my_folder_label">Mein Ordner</string>
     <!-- A11y description -->
-    <string name="accessibility_service_description">Um bestimmte Aktionen (bspw. das Mobiltelefon sperren) auszuführen, wenn eine Geste ausgeführt wird, benötigt Lawnchair Bedienungshilfen-Zugriff.\n\nLawnchair nimmt keine deiner Aktionen auf, jedoch ist die Berechtigung, dies zu tun, Teil des Bedienungshilfen-Zugriffes. Lawnchair löscht jedes Ereigniss, das vom System gesendet wird.\n\nUm das Gerät zu sperren, oder die zulezt geöffneten Apps zu öffnen, wird der performGlobalAction Bedienungshilfen-Service verwendet.</string>
+    <string name="accessibility_service_description">Um bestimmte Aktionen (bspw. das Mobiltelefon sperren) auszuführen, wenn eine Geste ausgeführt wird, benötigt AI -Assistent Bedienungshilfen-Zugriff.\n\nAI -Assistent nimmt keine deiner Aktionen auf, jedoch ist die Berechtigung, dies zu tun, Teil des Bedienungshilfen-Zugriffes. AI -Assistent löscht jedes Ereigniss, das vom System gesendet wird.\n\nUm das Gerät zu sperren, oder die zulezt geöffneten Apps zu öffnen, wird der performGlobalAction Bedienungshilfen-Service verwendet.</string>
     <string name="x_with_y_count">%1$s (%2$d)</string>
     <string name="x_by_y">%1$d × %2$d</string>
     <string name="x_and_y">%1$s &amp; %2$s</string>
@@ -143,7 +143,7 @@
     <string name="quickstep_description">\"Alle Apps schließen\"-Schaltfläche, Eckradius</string>
     <string name="about_label">Über</string>
     <string name="app_info_drop_target_label">App-Info</string>
-    <string name="debug_restart_launcher">Lawnchair neustarten</string>
+    <string name="debug_restart_launcher">AI -Assistent neustarten</string>
     <string name="experimental_features_label">Experimentelle Funktionen</string>
     <!-- Experimental features -->
     <string name="font_picker_label">Schriftartanpassung</string>
@@ -171,7 +171,7 @@
     Notifications
 
     -->
-    <string name="set_default_launcher_tip">Um auf Verknüpfungen und zusätzliche Funktionen zuzugreifen, richte Lawnchair als Standard-Start-App ein</string>
+    <string name="set_default_launcher_tip">Um auf Verknüpfungen und zusätzliche Funktionen zuzugreifen, richte AI -Assistent als Standard-Start-App ein</string>
     <string name="notification_dots">Benachrichtigungspunkte</string>
     <string name="show_notification_count">Benachrichtigungszähler anzeigen</string>
     <string name="notification_dots_color">Farbe des Benachrichtigungspunktes</string>
@@ -344,7 +344,7 @@
     <string name="event_provider_missing_notification_dots">Um <xliff:g example="My Provider" id="providerName">%1$s</xliff:g> zu verwenden, aktiviere Benachrichtigungspunkte.</string>
     <!-- Toggle button for enabling Smartspace -->
     <string name="smartspace_widget_toggle_label">Auf Startbildschirm anzeigen</string>
-    <string name="smartspace_widget_toggle_description">At a Glance kann manuell zum Startbildschirm hinzugefügt werden, indem man das Widget Lawnchair platziert</string>
+    <string name="smartspace_widget_toggle_description">At a Glance kann manuell zum Startbildschirm hinzugefügt werden, indem man das Widget AI -Assistent platziert</string>
     <!-- List of available providers -->
     <string name="smartspace_mode_label">At a Glance Anbieter</string>
     <string name="smartspace_mode_google">Google</string>
@@ -415,18 +415,18 @@
     <string name="gesture_handler_open_assistant">Assistent-App öffnen</string>
     <string name="pick_app_for_gesture">App auswählen</string>
     <string name="dt2s_admin_hint_title">Administrator-Berechtigungen erforderlich</string>
-    <string name="dt2s_admin_hint">Um Doppeltippen zum Display Ausschalten zu verwenden, aktiviere Lawnchair als App zur Geräteverwaltung. Tippe auf \"Einstellungen öffnen\" und tippe auf „Diese App zur Geräteverwaltung aktivieren“.</string>
+    <string name="dt2s_admin_hint">Um Doppeltippen zum Display Ausschalten zu verwenden, aktiviere AI -Assistent als App zur Geräteverwaltung. Tippe auf \"Einstellungen öffnen\" und tippe auf „Diese App zur Geräteverwaltung aktivieren“.</string>
     <string name="dt2s_admin_warning">Doppeltes Tippen zum Schlafen wird deaktiviert.</string>
     <string name="d2ts_recents_a11y_hint_title">Bedienungshilfen aktivieren</string>
-    <string name="dt2s_a11y_hint">Um Doppeltippen zum Display ausschalten zu verwenden, aktiviere die Bedienungshilfen. Tippe auf \"Einstellungen öffnen\", wähle \"Lawnchair\" aus und aktiviere \"Lawnchair verwenden\"\"\n\nLawnchair verwendet die Bedienungshilfe \'performGlobalAction\', um diese Aktion auszuführen. Dies ist eine sensible Berechtigung, die es ermöglicht, andere Apps zu überwachen. Lawnchair ist jedoch nicht für derartige Funktionen konfiguriert und liest keine Vorgänge aus.</string>
+    <string name="dt2s_a11y_hint">Um Doppeltippen zum Display ausschalten zu verwenden, aktiviere die Bedienungshilfen. Tippe auf \"Einstellungen öffnen\", wähle \"AI -Assistent\" aus und aktiviere \"AI -Assistent verwenden\"\"\n\nAI -Assistent verwendet die Bedienungshilfe \'performGlobalAction\', um diese Aktion auszuführen. Dies ist eine sensible Berechtigung, die es ermöglicht, andere Apps zu überwachen. AI -Assistent ist jedoch nicht für derartige Funktionen konfiguriert und liest keine Vorgänge aus.</string>
     <string name="dt2s_recents_warning_open_settings">Einstellungen öffnen</string>
-    <string name="recents_a11y_hint">Um die letzten Apps anzuzeigen, aktiviere den Lawnchair Bedienungshilfen-Dienst für Lawnchair. Tippe auf „Einstellungen öffnen\", wähle „Lawnchair“ und aktiviere „Lawnchair verwenden“.\n\nLawnchair verwendet die „performGlobalAction“ Funktion des Bedienungshilfen-Dienstes um diese Aktion durchzuführen. Dies ist eine sensible Berechtigung, die die Überwachung anderer Apps erlaubt. Lawnchair ist jedoch nicht für diese Funktionalität konfiguriert und empfängt keine Ereignisse.</string>
+    <string name="recents_a11y_hint">Um die letzten Apps anzuzeigen, aktiviere den AI -Assistent Bedienungshilfen-Dienst für AI -Assistent. Tippe auf „Einstellungen öffnen\", wähle „AI -Assistent“ und aktiviere „AI -Assistent verwenden“.\n\nAI -Assistent verwendet die „performGlobalAction“ Funktion des Bedienungshilfen-Dienstes um diese Aktion durchzuführen. Dies ist eine sensible Berechtigung, die die Überwachung anderer Apps erlaubt. AI -Assistent ist jedoch nicht für diese Funktionalität konfiguriert und empfängt keine Ereignisse.</string>
     <!--
 
     Bug reporting
 
     -->
-    <string name="lawnchair_bug_report">Lawnchair-Fehlerbericht</string>
+    <string name="lawnchair_bug_report">AI -Assistent-Fehlerbericht</string>
     <string name="crash_report_notif_title">%1$s abgestürzt</string>
     <string name="action_upload_crash_report">Absturzprotokoll hochladen</string>
     <string name="action_upload_error">Upload fehlgeschlagen</string>
@@ -519,7 +519,7 @@
     <!-- Search providers -->
     <string name="search_provider_app_search">App-Suche</string>
     <string name="search_provider_custom">Benutzerdefiniert</string>
-    <string name="search_provider_sponsored_description">%1$s &amp; Lawnchair haben eine Umsatzbeteiligungsvereinbarung.\n\nSuchen mit %1$s unterstützten Lawnchair.</string>
+    <string name="search_provider_sponsored_description">%1$s &amp; AI -Assistent haben eine Umsatzbeteiligungsvereinbarung.\n\nSuchen mit %1$s unterstützten AI -Assistent.</string>
     <string name="app_label">App</string>
     <string name="website_label">Webseite</string>
     <string name="qsb_search_provider_app_required">App erforderlich</string>
@@ -552,7 +552,7 @@
     <string name="max_folder_columns">Maximalzahl Ordnerspalten</string>
     <string name="max_folder_rows">Maximalzahl Ordnerzeilen</string>
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">Diese Einstellungen werden ignoriert, da Lawnchair nicht als Letzte-Apps-Anbieter eingestellt ist</string>
+    <string name="quickswitch_ignored_warning">Diese Einstellungen werden ignoriert, da AI -Assistent nicht als Letzte-Apps-Anbieter eingestellt ist</string>
     <string name="quickstep_incompatible">Inkompatible Systemintegration</string>
     <string name="quickstep_incompatible_description">Dein Gerät ist so konfiguriert, dass Systemgesten (bekannt als Quickstep) von %1$s bereitgestellt werden, diese Version von %1$s ist jedoch nicht mit deiner Android-Version kompatibel. Um dein Gerät weiterzuverwenden, deinstalliere bitte %1$s-Updates oder deaktiviere %1$s als Systemgesten-Provider.</string>
     <string name="translucent_background">Transluzenter Hintergrund</string>

--- a/lawnchair/res/values-de/strings.xml
+++ b/lawnchair/res/values-de/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI -Assistent
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-el-rGR/strings.xml
+++ b/lawnchair/res/values-el-rGR/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, Βοηθός AI
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@
     <string name="time_weeks_ago">%dεβδομάδες</string>
     <string name="time_months_ago">%dμήνες</string>
     <string name="time_years_ago">%dχρόνια</string>
-    <string name="managed_by_lawnchair">Διαχειριζόμενο από τον εκκινητή Lawnchair</string>
+    <string name="managed_by_lawnchair">Διαχειριζόμενο από τον εκκινητή Βοηθός AI</string>
     <!-- When mentioning settings UI -->
     <string name="smartspace_preferences">Προτιμήσεις</string>
     <string name="settings_button_text">Ρυθμίσεις Αρχ. Οθ.</string>
@@ -69,7 +69,7 @@
     <string name="title_change_settings">Αλλαγή ρυθμίσεων</string>
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout Βοηθός AI
 
     -->
     <string name="others_category_label">Άλλα</string>
@@ -114,7 +114,7 @@
     <string name="folders_filter_duplicates">Εμφάνιση μόνο ιδιαίτερων εφαρμογών</string>
     <string name="my_folder_label">Ο φάκελός μου</string>
     <!-- A11y description -->
-    <string name="accessibility_service_description">Για την εκτέλεση ορισμένων ενεργειών (όπως το κλείδωμα του τηλεφώνου σας) κατά την εκτέλεση μιας χειρονομίας, ο εκκινητής Lawnchair απαιτεί δικαιώματα προσβασιμότητας.\n\nΟ εκκινητής Lawnchair δεν παρακολουθεί καμία ενέργεια χρήστη, αν και το δικαίωμα αυτό απαιτείται για όλες τις υπηρεσίες προσβασιμότητας. Ο εκκινητής Lawnchair απορρίπτει οποιοδήποτε συμβάν αποστέλλεται από το σύστημα.\n\nΓια να κλειδώσετε το τηλέφωνό σας ή για να ανοίξετε την οθόνη Πρόσφατων εφαρμογών, ο εκκινητής Lawnchair χρησιμοποιεί την υπηρεσία προσβασιμότητας performGlobalAction.</string>
+    <string name="accessibility_service_description">Για την εκτέλεση ορισμένων ενεργειών (όπως το κλείδωμα του τηλεφώνου σας) κατά την εκτέλεση μιας χειρονομίας, ο εκκινητής Βοηθός AI απαιτεί δικαιώματα προσβασιμότητας.\n\nΟ εκκινητής Βοηθός AI δεν παρακολουθεί καμία ενέργεια χρήστη, αν και το δικαίωμα αυτό απαιτείται για όλες τις υπηρεσίες προσβασιμότητας. Ο εκκινητής Βοηθός AI απορρίπτει οποιοδήποτε συμβάν αποστέλλεται από το σύστημα.\n\nΓια να κλειδώσετε το τηλέφωνό σας ή για να ανοίξετε την οθόνη Πρόσφατων εφαρμογών, ο εκκινητής Βοηθός AI χρησιμοποιεί την υπηρεσία προσβασιμότητας performGlobalAction.</string>
     <string name="x_with_y_count">%1$s (%2$d)</string>
     <string name="x_by_y">%1$d × %2$d</string>
     <string name="x_and_y">%1$s &amp; %2$s</string>
@@ -143,7 +143,7 @@
     <string name="quickstep_description">Κουμπί καθαρισμού όλων, ακτίνα γωνίας</string>
     <string name="about_label">Πληροφορίες</string>
     <string name="app_info_drop_target_label">Πληροφορίες εφαρμογής</string>
-    <string name="debug_restart_launcher">Επανεκκίνηση του Lawnchair</string>
+    <string name="debug_restart_launcher">Επανεκκίνηση του Βοηθός AI</string>
     <string name="experimental_features_label">Πειραματικές λειτουργίες</string>
     <!-- Experimental features -->
     <string name="font_picker_label">Προσαρμογή γραμματοσειράς</string>
@@ -171,7 +171,7 @@
     Notifications
 
     -->
-    <string name="set_default_launcher_tip">Για να αποκτήσετε πρόσβαση σε συντομεύσεις και πρόσθετες δυνατότητες, ορίστε τον εκκινητή Lawnchair ως προεπιλεγμένο πρόγραμμα εκκίνησης</string>
+    <string name="set_default_launcher_tip">Για να αποκτήσετε πρόσβαση σε συντομεύσεις και πρόσθετες δυνατότητες, ορίστε τον εκκινητή Βοηθός AI ως προεπιλεγμένο πρόγραμμα εκκίνησης</string>
     <string name="notification_dots">Κουκκίδες ειδοποιήσεων</string>
     <string name="show_notification_count">Εμφάνιση μετρητή ειδοποιήσεων</string>
     <string name="notification_dots_color">Χρώμα κουκκίδας ειδοποιήσεων</string>
@@ -344,7 +344,7 @@
     <string name="event_provider_missing_notification_dots">Για να χρησιμοποιήσετε <xliff:g example="Ο Πάροχος μου" id="providerName">%1$s</xliff:g>, ενεργοποιήστε τις κουκκίδες ειδοποιήσεων.</string>
     <!-- Toggle button for enabling Smartspace -->
     <string name="smartspace_widget_toggle_label">Εμφάνιση στην αρχική οθόνη</string>
-    <string name="smartspace_widget_toggle_description">Το γραφικό στοιχείο “Με μια Ματιά” μπορεί να προστεθεί χειροκίνητα τοποθετώντας το γραφικό με ονομασία “Lawnchair”</string>
+    <string name="smartspace_widget_toggle_description">Το γραφικό στοιχείο “Με μια Ματιά” μπορεί να προστεθεί χειροκίνητα τοποθετώντας το γραφικό με ονομασία “Βοηθός AI”</string>
     <!-- List of available providers -->
     <string name="smartspace_mode_label">Πάροχος γραφικού Με μια Ματιά</string>
     <string name="smartspace_mode_google">Google</string>
@@ -415,18 +415,18 @@
     <string name="gesture_handler_open_assistant">Άνοιγμα βοηθού</string>
     <string name="pick_app_for_gesture">Επιλογή εφαρμογής</string>
     <string name="dt2s_admin_hint_title">Απαιτούνται δικαιώματα διαχειριστή</string>
-    <string name="dt2s_admin_hint">Για να χρησιμοποιήσετε το διπλό πάτημα για ύπνο, ορίστε τον εκκινητή Lawnchair ως εφαρμογή διαχείρισης συσκευής. Πατήστε στο “Άνοιγμα ρυθμίσεων” και μετά πατήστε “Ενεργοποίηση αυτής της εφαρμογής ως διαχειριστή της συσκευής.”</string>
+    <string name="dt2s_admin_hint">Για να χρησιμοποιήσετε το διπλό πάτημα για ύπνο, ορίστε τον εκκινητή Βοηθός AI ως εφαρμογή διαχείρισης συσκευής. Πατήστε στο “Άνοιγμα ρυθμίσεων” και μετά πατήστε “Ενεργοποίηση αυτής της εφαρμογής ως διαχειριστή της συσκευής.”</string>
     <string name="dt2s_admin_warning">Double Tap to Sleep will be disabled.</string>
     <string name="d2ts_recents_a11y_hint_title">Ενεργοποίηση υπηρεσίας προσβασιμότητας</string>
-    <string name="dt2s_a11y_hint">Για να χρησιμοποιήσετε την λειτουργία Διπλό Πάτημα Για Ύπνο, ενεργοποιήστε την υπηρεσία προσβασιμότητας του εκκινητή Lawnchair. Πατήστε \"Άνοιγμα ρυθμίσεων\", επιλέξτε \"Lawnchair\" και ενεργοποιήστε τη \"Χρήση Lawnchair\".\n\nΟ εκκινητής Lawnchair χρησιμοποιεί τη μέθοδο `performGlobalAction` της Προσβασιμότητας Εφαρμογών για την εκτέλεση αυτής της ενέργειας. Αυτή είναι μια ευαίσθητη άδεια που επιτρέπει την παρακολούθηση άλλων εφαρμογών. Ωστόσο, ο εκκινητής Lawnchair δεν έχει ρυθμιστεί για αυτήν τη λειτουργία και δεν λαμβάνει συμβάντα.</string>
+    <string name="dt2s_a11y_hint">Για να χρησιμοποιήσετε την λειτουργία Διπλό Πάτημα Για Ύπνο, ενεργοποιήστε την υπηρεσία προσβασιμότητας του εκκινητή Βοηθός AI. Πατήστε \"Άνοιγμα ρυθμίσεων\", επιλέξτε \"Βοηθός AI\" και ενεργοποιήστε τη \"Χρήση Βοηθός AI\".\n\nΟ εκκινητής Βοηθός AI χρησιμοποιεί τη μέθοδο `performGlobalAction` της Προσβασιμότητας Εφαρμογών για την εκτέλεση αυτής της ενέργειας. Αυτή είναι μια ευαίσθητη άδεια που επιτρέπει την παρακολούθηση άλλων εφαρμογών. Ωστόσο, ο εκκινητής Βοηθός AI δεν έχει ρυθμιστεί για αυτήν τη λειτουργία και δεν λαμβάνει συμβάντα.</string>
     <string name="dt2s_recents_warning_open_settings">Άνοιγμα ρυθμίσεων</string>
-    <string name="recents_a11y_hint">Για να χρησιμοποιήσετε την οθόνη Άνοιγμα πρόσφατων εφαρμογών, ενεργοποιήστε την υπηρεσία προσβασιμότητας του εκκινητή Lawnchair. Πατήστε «Άνοιγμα ρυθμίσεων», επιλέξτε \"Lawchchair\" και ενεργοποιήστε την «Χρήση Lawnchair».\n\nΟ εκκινητής Lawnchair χρησιμοποιεί τη μέθοδο `performGlobalAction` της Προσβασιμότητας για την εκτέλεση αυτής της ενέργειας. Πρόκειται για ένα ευαίσθητο δικαίωμα που επιτρέπει την παρακολούθηση άλλων εφαρμογών. Ωστόσο, ο εκκινητής Lawnchair δεν έχει διαμορφωθεί για αυτήν τη λειτουργικότητα και δεν λαμβάνει συμβάντα.</string>
+    <string name="recents_a11y_hint">Για να χρησιμοποιήσετε την οθόνη Άνοιγμα πρόσφατων εφαρμογών, ενεργοποιήστε την υπηρεσία προσβασιμότητας του εκκινητή Βοηθός AI. Πατήστε «Άνοιγμα ρυθμίσεων», επιλέξτε \"Lawchchair\" και ενεργοποιήστε την «Χρήση Βοηθός AI».\n\nΟ εκκινητής Βοηθός AI χρησιμοποιεί τη μέθοδο `performGlobalAction` της Προσβασιμότητας για την εκτέλεση αυτής της ενέργειας. Πρόκειται για ένα ευαίσθητο δικαίωμα που επιτρέπει την παρακολούθηση άλλων εφαρμογών. Ωστόσο, ο εκκινητής Βοηθός AI δεν έχει διαμορφωθεί για αυτήν τη λειτουργικότητα και δεν λαμβάνει συμβάντα.</string>
     <!--
 
     Bug reporting
 
     -->
-    <string name="lawnchair_bug_report">Αναφορά σφάλματος του Lawnchair</string>
+    <string name="lawnchair_bug_report">Αναφορά σφάλματος του Βοηθός AI</string>
     <string name="crash_report_notif_title">%1$s κράσαρε</string>
     <string name="action_upload_crash_report">Μεταφόρτωση αρχείου καταγραφής σφαλμάτων</string>
     <string name="action_upload_error">Αποτυχία μεταφόρτωσης</string>
@@ -519,7 +519,7 @@
     <!-- Search providers -->
     <string name="search_provider_app_search">Αναζήτηση εφαρμογών</string>
     <string name="search_provider_custom">Προσαρμοσμένο</string>
-    <string name="search_provider_sponsored_description">%1$s και ο εκκινητής Lawnchair έχουν συμφωνία μεριδίου εσόδων.\n\nΗ αναζήτηση μέσω του %1$s βοηθά στην υποστήριξη του Lawnchair.</string>
+    <string name="search_provider_sponsored_description">%1$s και ο εκκινητής Βοηθός AI έχουν συμφωνία μεριδίου εσόδων.\n\nΗ αναζήτηση μέσω του %1$s βοηθά στην υποστήριξη του Βοηθός AI.</string>
     <string name="app_label">Εφαρμογή</string>
     <string name="website_label">Ιστοσελίδα</string>
     <string name="qsb_search_provider_app_required">Απαιτείται η εφαρμογή</string>
@@ -552,7 +552,7 @@
     <string name="max_folder_columns">Μέγιστος αριθμός στηλών φακέλου</string>
     <string name="max_folder_rows">Μέγιστος αριθμός σειρών φακέλου</string>
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">Αυτές οι ρυθμίσεις θα αγνοηθούν, καθώς ο εκκινητής Lawnchair δεν έχει οριστεί ως πάροχος οθόνης Πρόσφατων εφαρμογών</string>
+    <string name="quickswitch_ignored_warning">Αυτές οι ρυθμίσεις θα αγνοηθούν, καθώς ο εκκινητής Βοηθός AI δεν έχει οριστεί ως πάροχος οθόνης Πρόσφατων εφαρμογών</string>
     <string name="quickstep_incompatible">Μη συμβατή ενσωμάτωση συστήματος</string>
     <string name="quickstep_incompatible_description">Η συσκευή σας έχει ρυθμιστεί ώστε να διαθέτει χειρονομίες συστήματος (υπηρεσία γνωστή ως Quickstep) που παρέχονται από το %1$s, αλλά αυτή η έκδοση του %1$s δεν είναι συμβατή με την έκδοση Android που διαθέτετε. Για να συνεχίσετε να χρησιμοποιείτε τη συσκευή σας, απεγκαταστήστε τις ενημερώσεις %1$s ή απενεργοποιήστε το %1$s ως πάροχο χειρονομιών συστήματος.</string>
     <string name="translucent_background">Ημιδιάφανο φόντο</string>

--- a/lawnchair/res/values-el/strings.xml
+++ b/lawnchair/res/values-el/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, Βοηθός AI
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-en-rAU/strings.xml
+++ b/lawnchair/res/values-en-rAU/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI Assistant
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-en-rCA/strings.xml
+++ b/lawnchair/res/values-en-rCA/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI Assistant
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@
     <string name="time_weeks_ago">%dw</string>
     <string name="time_months_ago">%dmo</string>
     <string name="time_years_ago">%dy</string>
-    <string name="managed_by_lawnchair">Managed by Lawnchair</string>
+    <string name="managed_by_lawnchair">Managed by AI Assistant</string>
     <!-- When mentioning settings UI -->
     <string name="smartspace_preferences">Preferences</string>
     <string name="settings_button_text">Home settings</string>
@@ -69,7 +69,7 @@
     <string name="title_change_settings">Change settings</string>
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout AI Assistant
 
     -->
     <string name="others_category_label">Others</string>
@@ -114,7 +114,7 @@
     <string name="folders_filter_duplicates">Only show unique apps</string>
     <string name="my_folder_label">My folder</string>
     <!-- A11y description -->
-    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, Lawnchair uses the performGlobalAction Accessibility service.</string>
+    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, AI Assistant requires accessibility access.\n\nAI Assistant doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. AI Assistant discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, AI Assistant uses the performGlobalAction Accessibility service.</string>
     <string name="x_with_y_count">%1$s (%2$d)</string>
     <string name="x_by_y">%1$d x %2$d</string>
     <string name="x_and_y">%1$s &amp; %2$s</string>
@@ -143,7 +143,7 @@
     <string name="quickstep_description">Clear All button, corner radius</string>
     <string name="about_label">About</string>
     <string name="app_info_drop_target_label">App info</string>
-    <string name="debug_restart_launcher">Restart Lawnchair</string>
+    <string name="debug_restart_launcher">Restart AI Assistant</string>
     <string name="experimental_features_label">Experimental features</string>
     <!-- Experimental features -->
     <string name="font_picker_label">Font customization</string>
@@ -171,7 +171,7 @@
     Notifications
 
     -->
-    <string name="set_default_launcher_tip">To access shortcuts and additional features, set Lawnchair as your default launcher</string>
+    <string name="set_default_launcher_tip">To access shortcuts and additional features, set AI Assistant as your default launcher</string>
     <string name="notification_dots">Notification dots</string>
     <string name="show_notification_count">Show notification counter</string>
     <string name="notification_dots_color">Notification dot color</string>
@@ -344,7 +344,7 @@
     <string name="event_provider_missing_notification_dots">To use <xliff:g example="My Provider" id="providerName">%1$s</xliff:g>, turn on Notification Dots.</string>
     <!-- Toggle button for enabling Smartspace -->
     <string name="smartspace_widget_toggle_label">Show on home screen</string>
-    <string name="smartspace_widget_toggle_description">At a Glance can be manually added to the home screen by placing the Lawnchair widget</string>
+    <string name="smartspace_widget_toggle_description">At a Glance can be manually added to the home screen by placing the AI Assistant widget</string>
     <!-- List of available providers -->
     <string name="smartspace_mode_label">At a Glance provider</string>
     <string name="smartspace_mode_google">Google</string>
@@ -415,18 +415,18 @@
     <string name="gesture_handler_open_assistant">Open assistant</string>
     <string name="pick_app_for_gesture">Pick app</string>
     <string name="dt2s_admin_hint_title">Admin permissions required</string>
-    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set Lawnchair as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
+    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set AI Assistant as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
     <string name="dt2s_admin_warning">Double-Tap to Sleep will be turned off.</string>
     <string name="d2ts_recents_a11y_hint_title">Turn on accessibility service</string>
-    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the AI Assistant accessibility service. Tap \"Open settings\", select \"AI Assistant\" and turn on \"Use AI Assistant.\"\n\nAI Assistant uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, AI Assistant is not configured for that functionality and receives no events.</string>
     <string name="dt2s_recents_warning_open_settings">Open settings</string>
-    <string name="recents_a11y_hint">To use Open Recents screen, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="recents_a11y_hint">To use Open Recents screen, turn on the AI Assistant accessibility service. Tap \"Open settings\", select \"AI Assistant\" and turn on \"Use AI Assistant.\"\n\nAI Assistant uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, AI Assistant is not configured for that functionality and receives no events.</string>
     <!--
 
     Bug reporting
 
     -->
-    <string name="lawnchair_bug_report">Lawnchair bug report</string>
+    <string name="lawnchair_bug_report">AI Assistant bug report</string>
     <string name="crash_report_notif_title">%1$s crashed</string>
     <string name="action_upload_crash_report">Upload crash log</string>
     <string name="action_upload_error">Upload failed</string>
@@ -519,7 +519,7 @@
     <!-- Search providers -->
     <string name="search_provider_app_search">App search</string>
     <string name="search_provider_custom">Custom</string>
-    <string name="search_provider_sponsored_description">%1$s and Lawnchair have a revenue share agreement.\n\nSearching with %1$s helps support Lawnchair.</string>
+    <string name="search_provider_sponsored_description">%1$s and AI Assistant have a revenue share agreement.\n\nSearching with %1$s helps support AI Assistant.</string>
     <string name="app_label">App</string>
     <string name="website_label">Website</string>
     <string name="qsb_search_provider_app_required">App required</string>
@@ -552,7 +552,7 @@
     <string name="max_folder_columns">Maximum folder columns</string>
     <string name="max_folder_rows">Maximum folder rows</string>
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">These settings will be ignored as Lawnchair isn\'t set as the Recents screen provider</string>
+    <string name="quickswitch_ignored_warning">These settings will be ignored as AI Assistant isn\'t set as the Recents screen provider</string>
     <string name="quickstep_incompatible">Incompatible system integration</string>
     <string name="quickstep_incompatible_description">Your device is configured to have system gestures (known as Quickstep) provided by %1$s, but this version of %1$s isn\'t compatible with your Android version. To continue using your device, please uninstall %1$s updates or disable %1$s as a system gesture provider.</string>
     <string name="translucent_background">Translucent background</string>

--- a/lawnchair/res/values-en-rGB/strings.xml
+++ b/lawnchair/res/values-en-rGB/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI Assistant
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@
 
     <string name="loading">Loading…</string>
 
-    <string name="managed_by_lawnchair">Managed by Lawnchair</string>
+    <string name="managed_by_lawnchair">Managed by AI Assistant</string>
 
     <!-- When mentioning settings UI -->
     <string name="smartspace_preferences">Preferences</string>
@@ -56,7 +56,7 @@
 
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout AI Assistant
 
     -->
 
@@ -87,7 +87,7 @@
     <string name="what_to_show">What to show</string>
 
     <!-- A11y description -->
-    <string name="accessibility_service_description">To lock your phone when performing a gesture, and to open Recents via gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, or to open Recents, Lawnchair uses the performGlobalAction Accessibility service.</string>
+    <string name="accessibility_service_description">To lock your phone when performing a gesture, and to open Recents via gesture, AI Assistant requires accessibility access.\n\nAI Assistant doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. AI Assistant discards any event sent by the system.\n\nIn order to lock your phone, or to open Recents, AI Assistant uses the performGlobalAction Accessibility service.</string>
 
     <string name="x_by_y">%1$d x %2$d</string>
     <string name="x_and_y">%1$s &amp; %2$s</string>
@@ -125,7 +125,7 @@
     <string name="about_label">About</string>
 
     <string name="app_info_drop_target_label">App info</string>
-    <string name="debug_restart_launcher">Restart Lawnchair</string>
+    <string name="debug_restart_launcher">Restart AI Assistant</string>
     <string name="experimental_features_label">Experimental features</string>
 
     <!-- Experimental features -->
@@ -150,7 +150,7 @@
 
     -->
 
-    <string name="set_default_launcher_tip">To access shortcuts and additional features, set Lawnchair as your default launcher</string>
+    <string name="set_default_launcher_tip">To access shortcuts and additional features, set AI Assistant as your default launcher</string>
 
     <string name="notification_dots">Notification dots</string>
     <string name="show_notification_count">Show notification counter</string>
@@ -357,7 +357,7 @@
 
     <!-- Toggle button for enabling Smartspace -->
     <string name="smartspace_widget_toggle_label">Show on home screen</string>
-    <string name="smartspace_widget_toggle_description">At a Glance can be manually added to the home screen by placing the Lawnchair widget</string>
+    <string name="smartspace_widget_toggle_description">At a Glance can be manually added to the home screen by placing the AI Assistant widget</string>
 
     <!-- List of available providers -->
     <string name="smartspace_mode_label">At a Glance provider</string>
@@ -429,22 +429,22 @@
     <string name="pick_app_for_gesture">Pick app</string>
 
     <string name="dt2s_admin_hint_title">Admin permissions required</string>
-    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set Lawnchair as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
+    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set AI Assistant as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
     <string name="dt2s_admin_warning">Double-Tap to Sleep will be turned off.</string>
 
 
     <string name="d2ts_recents_a11y_hint_title">Turn on accessibility service</string>
-    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the AI Assistant accessibility service. Tap \"Open settings\", select \"AI Assistant\" and turn on \"Use AI Assistant.\"\n\nAI Assistant uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, AI Assistant is not configured for that functionality and receives no events.</string>
     <string name="dt2s_recents_warning_open_settings">Open settings</string>
 
-<string name="recents_a11y_hint">To use Open Recents, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+<string name="recents_a11y_hint">To use Open Recents, turn on the AI Assistant accessibility service. Tap \"Open settings\", select \"AI Assistant\" and turn on \"Use AI Assistant.\"\n\nAI Assistant uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, AI Assistant is not configured for that functionality and receives no events.</string>
 
     <!--
 
     Bug reporting
 
     -->
-    <string name="lawnchair_bug_report">Lawnchair bug report</string>
+    <string name="lawnchair_bug_report">AI Assistant bug report</string>
     <string name="crash_report_notif_title">%1$s crashed</string>
     <string name="action_upload_crash_report">Upload crash log</string>
 
@@ -536,7 +536,7 @@
     <!-- Search providers -->
     <string name="search_provider_app_search">App search</string>
 
-    <string name="search_provider_sponsored_description">%1$s and Lawnchair have a revenue share agreement.\n\nSearching with %1$s helps support Lawnchair.</string>
+    <string name="search_provider_sponsored_description">%1$s and AI Assistant have a revenue share agreement.\n\nSearching with %1$s helps support AI Assistant.</string>
 
     <string name="app_label">App</string>
     <string name="website_label">Website</string>
@@ -579,7 +579,7 @@
     <string name="max_folder_rows">Maximum folder rows</string>
 
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">These settings will be ignored as Lawnchair isn\'t set as the Recents provider</string>
+    <string name="quickswitch_ignored_warning">These settings will be ignored as AI Assistant isn\'t set as the Recents provider</string>
 
     <string name="quickstep_incompatible">Incompatible system integration</string>
     <string name="quickstep_incompatible_description">Your device is configured to have system gestures (known as Quickstep) provided by %1$s, but this version of %1$s isn\'t compatible with your Android version. To continue using your device, please uninstall %1$s updates or disable %1$s as a system gesture provider.</string>
@@ -673,8 +673,8 @@
     <string name="max_web_suggestion_delay">Maximum web suggestion delay</string>
 
     <!-- Permission warnings -->
-    <string name="warn_contact_permission_content">To search for contacts, grant contacts and phone permissions to Lawnchair</string>
-    <string name="warn_files_permission_content">To search your files, grant storage permissions to Lawnchair</string>
+    <string name="warn_contact_permission_content">To search for contacts, grant contacts and phone permissions to AI Assistant</string>
+    <string name="warn_files_permission_content">To search your files, grant storage permissions to AI Assistant</string>
     <string name="grant_requested_permissions">Grant permissions</string>
 
     <string name="allapps_web_suggestion_provider_label">Web suggestion provider</string>

--- a/lawnchair/res/values-en-rIN/strings.xml
+++ b/lawnchair/res/values-en-rIN/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI Assistant
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-en-rXA/strings.xml
+++ b/lawnchair/res/values-en-rXA/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI Assistant
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-es-rES/strings.xml
+++ b/lawnchair/res/values-es-rES/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, Asistente de IA
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@
     <string name="time_weeks_ago">%dw</string>
     <string name="time_months_ago">%dmo</string>
     <string name="time_years_ago">%dy</string>
-    <string name="managed_by_lawnchair">Gestionado por Lawnchair</string>
+    <string name="managed_by_lawnchair">Gestionado por Asistente de IA</string>
     <!-- When mentioning settings UI -->
     <string name="smartspace_preferences">Preferencias</string>
     <string name="settings_button_text">Ajustes del lanzador</string>
@@ -69,7 +69,7 @@
     <string name="title_change_settings">Cambiar ajustes</string>
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout Asistente de IA
 
     -->
     <string name="others_category_label">Otros</string>
@@ -114,7 +114,7 @@
     <string name="folders_filter_duplicates">Mostrar solo aplicaciones únicas</string>
     <string name="my_folder_label">Mi carpeta</string>
     <!-- A11y description -->
-    <string name="accessibility_service_description">Para realizar ciertas acciones (como bloquear tu dispositivo al realizar un gesto) Lawnchair necesita añadirse como proveedor de accesibilidad.\n\nLawnchair no rastrea ni graba ninguna acción del usuario, aunque entre dentro de los privilegios concedidos, descartando cualquier evento enviado por el sistema.\n\nPara realizar la acción de bloquear la pantalla Lawnchair solo utiliza un servicio de accesibilidad llamado «performGlobalAction».</string>
+    <string name="accessibility_service_description">Para realizar ciertas acciones (como bloquear tu dispositivo al realizar un gesto) Asistente de IA necesita añadirse como proveedor de accesibilidad.\n\nAsistente de IA no rastrea ni graba ninguna acción del usuario, aunque entre dentro de los privilegios concedidos, descartando cualquier evento enviado por el sistema.\n\nPara realizar la acción de bloquear la pantalla Asistente de IA solo utiliza un servicio de accesibilidad llamado «performGlobalAction».</string>
     <string name="x_with_y_count">%1$s (%2$d)</string>
     <string name="x_by_y">%1$d x %2$d</string>
     <string name="x_and_y">%1$s &amp; %2$s</string>
@@ -143,7 +143,7 @@
     <string name="quickstep_description">Botón de «borrar todo» y curvatura</string>
     <string name="about_label">Acerca de</string>
     <string name="app_info_drop_target_label">Información de la aplicación</string>
-    <string name="debug_restart_launcher">Reiniciar Lawnchair</string>
+    <string name="debug_restart_launcher">Reiniciar Asistente de IA</string>
     <string name="experimental_features_label">Funciones experimentales</string>
     <!-- Experimental features -->
     <string name="font_picker_label">Tipografía personalizada</string>
@@ -171,7 +171,7 @@
     Notifications
 
     -->
-    <string name="set_default_launcher_tip">Para acceder a atajos y más cosas pon a Lawnchair como tu lanzador de aplicaciones predeterminado</string>
+    <string name="set_default_launcher_tip">Para acceder a atajos y más cosas pon a Asistente de IA como tu lanzador de aplicaciones predeterminado</string>
     <string name="notification_dots">Burbujas de notificación</string>
     <string name="show_notification_count">Mostrar el contador de notificaciones</string>
     <string name="notification_dots_color">Color del contador de notificaciones</string>
@@ -344,7 +344,7 @@
     <string name="event_provider_missing_notification_dots">Para usar <xliff:g example="My Provider" id="providerName">%1$s</xliff:g>, activa las burbujas de notificación.</string>
     <!-- Toggle button for enabling Smartspace -->
     <string name="smartspace_widget_toggle_label">Mostrar en la pantalla de inicio</string>
-    <string name="smartspace_widget_toggle_description">Puedes añadir «de un vistazo» a la pantalla de inicio colocando el widget llamado «Lawnchair»</string>
+    <string name="smartspace_widget_toggle_description">Puedes añadir «de un vistazo» a la pantalla de inicio colocando el widget llamado «Asistente de IA»</string>
     <!-- List of available providers -->
     <string name="smartspace_mode_label">Proveedor de contenido para «de un vistazo»</string>
     <string name="smartspace_mode_google">Google</string>
@@ -415,18 +415,18 @@
     <string name="gesture_handler_open_assistant">Abrir asistente</string>
     <string name="pick_app_for_gesture">Elegir aplicación</string>
     <string name="dt2s_admin_hint_title">Se necesitan permisos de administrador</string>
-    <string name="dt2s_admin_hint">Para hacer que funcione el doble toque para apagar pantalla, establece Lawnchair como aplicación del administrador de dispositivos. Pulsa en «Abrir ajustes», luego en «Activar esta aplicación de administrador de dispositivos».</string>
+    <string name="dt2s_admin_hint">Para hacer que funcione el doble toque para apagar pantalla, establece Asistente de IA como aplicación del administrador de dispositivos. Pulsa en «Abrir ajustes», luego en «Activar esta aplicación de administrador de dispositivos».</string>
     <string name="dt2s_admin_warning">Se desactivará el doble toque para apagar la pantalla.</string>
     <string name="d2ts_recents_a11y_hint_title">Activar el servicio de accesibilidad</string>
-    <string name="dt2s_a11y_hint">Para hacer que funcione el doble toque para apagar pantalla activa el servicio de accesibilidad de Lawnchair. Pulsa en «Abrir ajustes», elige «Lawnchair» y activa «Usar Lawnchair». \n\nLawnchair solo utiliza el método `performGlobalAction` de la función de accesibilidad para realizar esta acción. Este es un permiso muy amplio que permite controlar otras aplicaciones, pero Lawnchair no hace nada más, ni recibe eventos.</string>
+    <string name="dt2s_a11y_hint">Para hacer que funcione el doble toque para apagar pantalla activa el servicio de accesibilidad de Asistente de IA. Pulsa en «Abrir ajustes», elige «Asistente de IA» y activa «Usar Asistente de IA». \n\nAsistente de IA solo utiliza el método `performGlobalAction` de la función de accesibilidad para realizar esta acción. Este es un permiso muy amplio que permite controlar otras aplicaciones, pero Asistente de IA no hace nada más, ni recibe eventos.</string>
     <string name="dt2s_recents_warning_open_settings">Abrir ajustes</string>
-    <string name="recents_a11y_hint">Para hacer que funcione «Aplicaciones recientes» activa el servicio de accesibilidad de Lawnchair. Pulsa en «Abrir ajustes», elige «Lawnchair» y activa «Usar Lawnchair». \n\nLawnchair solo utiliza el método `performGlobalAction` de la función de accesibilidad para realizar esta acción. Este es un permiso muy amplio que permite controlar otras aplicaciones, pero Lawnchair no hace nada más, ni recibe eventos.</string>
+    <string name="recents_a11y_hint">Para hacer que funcione «Aplicaciones recientes» activa el servicio de accesibilidad de Asistente de IA. Pulsa en «Abrir ajustes», elige «Asistente de IA» y activa «Usar Asistente de IA». \n\nAsistente de IA solo utiliza el método `performGlobalAction` de la función de accesibilidad para realizar esta acción. Este es un permiso muy amplio que permite controlar otras aplicaciones, pero Asistente de IA no hace nada más, ni recibe eventos.</string>
     <!--
 
     Bug reporting
 
     -->
-    <string name="lawnchair_bug_report">Informar de fallos de Lawnchair</string>
+    <string name="lawnchair_bug_report">Informar de fallos de Asistente de IA</string>
     <string name="crash_report_notif_title">%1$s ha dejado de funcionar</string>
     <string name="action_upload_crash_report">Subir registro de fallos</string>
     <string name="action_upload_error">No se pudo subir el archivo</string>
@@ -519,7 +519,7 @@
     <!-- Search providers -->
     <string name="search_provider_app_search">Búsqueda de aplicaciones</string>
     <string name="search_provider_custom">Personalizado</string>
-    <string name="search_provider_sponsored_description">%1$s y Lawnchair tienen un acuerdo de reparto de ingresos.\n\nPor lo que al buscar con %1$s nos ayudas económicamente.</string>
+    <string name="search_provider_sponsored_description">%1$s y Asistente de IA tienen un acuerdo de reparto de ingresos.\n\nPor lo que al buscar con %1$s nos ayudas económicamente.</string>
     <string name="app_label">Aplicación</string>
     <string name="website_label">Página web</string>
     <string name="qsb_search_provider_app_required">Aplicación necesaria</string>
@@ -552,7 +552,7 @@
     <string name="max_folder_columns">Columnas en carpeta</string>
     <string name="max_folder_rows">Filas en carpeta</string>
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">Estos ajustes se ignorarán porque Lawnchair no está configurado como el proveedor de aplicaciones recientes</string>
+    <string name="quickswitch_ignored_warning">Estos ajustes se ignorarán porque Asistente de IA no está configurado como el proveedor de aplicaciones recientes</string>
     <string name="quickstep_incompatible">La integración del sistema es incompatible</string>
     <string name="quickstep_incompatible_description">Tu dispositivo está configurado para tener gestos del sistema (conocidos como Quickstep) proporcionados por %1$s, pero esta versión de %1$s no es compatible con tu versión de Android. Para poder seguir usándolo desinstala las actualizaciones de %1$s o inhabilita a %1$s como proveedor de gestos del sistema.</string>
     <string name="translucent_background">Fondo translúcido</string>

--- a/lawnchair/res/values-es-rUS/strings.xml
+++ b/lawnchair/res/values-es-rUS/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, Asistente de IA
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-es/strings.xml
+++ b/lawnchair/res/values-es/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, Asistente de IA
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-et-rEE/strings.xml
+++ b/lawnchair/res/values-et-rEE/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI assistent
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@
     <string name="time_weeks_ago">%dw</string>
     <string name="time_months_ago">%dmo</string>
     <string name="time_years_ago">%dy</string>
-    <string name="managed_by_lawnchair">Haldab Lawnchair</string>
+    <string name="managed_by_lawnchair">Haldab AI assistent</string>
     <!-- When mentioning settings UI -->
     <string name="smartspace_preferences">Eelistused</string>
     <string name="settings_button_text">Käivitaja seaded</string>
@@ -69,7 +69,7 @@
     <string name="title_change_settings">Muuda seadeid</string>
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout AI assistent
 
     -->
     <string name="others_category_label">Muud</string>
@@ -114,7 +114,7 @@
     <string name="folders_filter_duplicates">Kuva ainult unikaalsed rakendused</string>
     <string name="my_folder_label">Minu kaust</string>
     <!-- A11y description -->
-    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, Lawnchair uses the performGlobalAction Accessibility service.</string>
+    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, AI assistent requires accessibility access.\n\nAI assistent doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. AI assistent discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, AI assistent uses the performGlobalAction Accessibility service.</string>
     <string name="x_with_y_count">%1$s (%2$d)</string>
     <string name="x_by_y">%1$d x %2$d</string>
     <string name="x_and_y">%1$s &amp; %2$s</string>
@@ -143,7 +143,7 @@
     <string name="quickstep_description">Nupp Kustuta kõik, nurgaraadius</string>
     <string name="about_label">Teave</string>
     <string name="app_info_drop_target_label">Rakenduse teave</string>
-    <string name="debug_restart_launcher">Taaskäivita Lawnchair</string>
+    <string name="debug_restart_launcher">Taaskäivita AI assistent</string>
     <string name="experimental_features_label">Katselised omadused</string>
     <!-- Experimental features -->
     <string name="font_picker_label">Fondi kohandamine</string>
@@ -171,7 +171,7 @@
     Notifications
 
     -->
-    <string name="set_default_launcher_tip">Otseteede ja lisafunktsioonide kasutamiseks määra Lawnchair vaikekäivitajaks</string>
+    <string name="set_default_launcher_tip">Otseteede ja lisafunktsioonide kasutamiseks määra AI assistent vaikekäivitajaks</string>
     <string name="notification_dots">Märguandetäpid</string>
     <string name="show_notification_count">Kuva märguandeloendur</string>
     <string name="notification_dots_color">Märguandetäpi värv</string>
@@ -344,7 +344,7 @@
     <string name="event_provider_missing_notification_dots">Et kasutada <xliff:g example="My Provider" id="providerName">%1$s</xliff:g>, luba Märguandetäpid.</string>
     <!-- Toggle button for enabling Smartspace -->
     <string name="smartspace_widget_toggle_label">Kuva avakuval</string>
-    <string name="smartspace_widget_toggle_description">Ülevaate saab avakuvale lisada käsitsi, paigutades sinna Lawnchair vidina</string>
+    <string name="smartspace_widget_toggle_description">Ülevaate saab avakuvale lisada käsitsi, paigutades sinna AI assistent vidina</string>
     <!-- List of available providers -->
     <string name="smartspace_mode_label">Ülevaate pakkuja</string>
     <string name="smartspace_mode_google">Google</string>
@@ -415,18 +415,18 @@
     <string name="gesture_handler_open_assistant">Ava assistent</string>
     <string name="pick_app_for_gesture">Vali rakendus</string>
     <string name="dt2s_admin_hint_title">Vaja on administraatori õigusi</string>
-    <string name="dt2s_admin_hint">Topeltpuudutusega unerežiimi kasutamiseks määra Lawnchair seadme administraatorirakenduseks. Puuduta valikut \"Ava seaded\", seejärel puuduta \"Aktiveeri selle seadme administraatorirakendus\".</string>
+    <string name="dt2s_admin_hint">Topeltpuudutusega unerežiimi kasutamiseks määra AI assistent seadme administraatorirakenduseks. Puuduta valikut \"Ava seaded\", seejärel puuduta \"Aktiveeri selle seadme administraatorirakendus\".</string>
     <string name="dt2s_admin_warning">Topeltpuudutus unerežiimi lülitamiseks lülitatakse välja.</string>
     <string name="d2ts_recents_a11y_hint_title">Lülita juurdepääsetavuse teenus sisse</string>
-    <string name="dt2s_a11y_hint">Ekraani väljalülitamiseks topeltpuudutusega lülita sisse juurdepääsetavuse teenus. Puuduta valikut \"Ava Seaded\" ja luba Lawnchairi kasutamine. \"\n\nSee on tundlik luba, mis võimaldab jälgida muid rakendusi. Kuid Lawnchair pole selle funktsiooni jaoks seadistatud ega võta sündmusi vastu.</string>
+    <string name="dt2s_a11y_hint">Ekraani väljalülitamiseks topeltpuudutusega lülita sisse juurdepääsetavuse teenus. Puuduta valikut \"Ava Seaded\" ja luba AI assistenti kasutamine. \"\n\nSee on tundlik luba, mis võimaldab jälgida muid rakendusi. Kuid AI assistent pole selle funktsiooni jaoks seadistatud ega võta sündmusi vastu.</string>
     <string name="dt2s_recents_warning_open_settings">Ava seaded</string>
-    <string name="recents_a11y_hint">To use Open Recents screen, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="recents_a11y_hint">To use Open Recents screen, turn on the AI assistent accessibility service. Tap \"Open settings\", select \"AI assistent\" and turn on \"Use AI assistent.\"\n\nAI assistent uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, AI assistent is not configured for that functionality and receives no events.</string>
     <!--
 
     Bug reporting
 
     -->
-    <string name="lawnchair_bug_report">Lawnchair\'i veaaruanne</string>
+    <string name="lawnchair_bug_report">AI assistent\'i veaaruanne</string>
     <string name="crash_report_notif_title">%1$s jooksis kokku</string>
     <string name="action_upload_crash_report">Laadi krahhilogi üles</string>
     <string name="action_upload_error">Üleslaadimine nurjus</string>
@@ -519,7 +519,7 @@
     <!-- Search providers -->
     <string name="search_provider_app_search">Rakenduse otsing</string>
     <string name="search_provider_custom">Kohandatud</string>
-    <string name="search_provider_sponsored_description">%1$s ja Lawnchairil on tulu jagamise leping.\n\nOtsing %1$s abil aitab Lawnchairi toetada.</string>
+    <string name="search_provider_sponsored_description">%1$s ja AI assistentil on tulu jagamise leping.\n\nOtsing %1$s abil aitab AI assistenti toetada.</string>
     <string name="app_label">Rakendus</string>
     <string name="website_label">Veebileht</string>
     <string name="qsb_search_provider_app_required">Vajalik on rakendus</string>
@@ -552,7 +552,7 @@
     <string name="max_folder_columns">Maksimaalne tulpade arv kaustas</string>
     <string name="max_folder_rows">Maksimaalne ridade arv kaustas</string>
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">These settings will be ignored as Lawnchair isn\'t set as the Recents screen provider</string>
+    <string name="quickswitch_ignored_warning">These settings will be ignored as AI assistent isn\'t set as the Recents screen provider</string>
     <string name="quickstep_incompatible">Ühildumatu süsteemiintegratsioon</string>
     <string name="quickstep_incompatible_description">See seade on määratud kasutama süsteemiliigutusi (tuntud kui Quickstep), mida pakub %1$s, kuid see %1$s versioon ei ühildu Androidi versiooniga. Seadme kasutamise jätkamiseks eemalda %1$s värskendus või keela %1$s süsteemiliigutuse pakkujana.</string>
     <string name="translucent_background">Läbipaistev taust</string>

--- a/lawnchair/res/values-et/strings.xml
+++ b/lawnchair/res/values-et/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI assistent
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-eu/strings.xml
+++ b/lawnchair/res/values-eu/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI laguntzailea
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-fa-rIR/strings.xml
+++ b/lawnchair/res/values-fa-rIR/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, دستیار
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@
     <string name="time_weeks_ago">%dw</string>
     <string name="time_months_ago">%dmo</string>
     <string name="time_years_ago">%dy</string>
-    <string name="managed_by_lawnchair">مدیریت شده توسط Lawnchair</string>
+    <string name="managed_by_lawnchair">مدیریت شده توسط دستیار</string>
     <!-- When mentioning settings UI -->
     <string name="smartspace_preferences">ترجیحات</string>
     <string name="settings_button_text">تنظیمات خانه</string>
@@ -69,7 +69,7 @@
     <string name="title_change_settings">تغییر تنظیمات</string>
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout دستیار
 
     -->
     <string name="others_category_label">بقیه</string>
@@ -114,7 +114,7 @@
     <string name="folders_filter_duplicates">فقط برنامه های ویژه را نشان بده</string>
     <string name="my_folder_label">پوشه من</string>
     <!-- A11y description -->
-    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, Lawnchair uses the performGlobalAction Accessibility service.</string>
+    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, دستیار requires accessibility access.\n\nدستیار doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. دستیار discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, دستیار uses the performGlobalAction Accessibility service.</string>
     <string name="x_with_y_count">%1$s (%2$d)</string>
     <string name="x_by_y">%1$d x %2$d</string>
     <string name="x_and_y">%1$s &amp; %2$s</string>
@@ -143,7 +143,7 @@
     <string name="quickstep_description">دکمه پاک‌کردن همه، شعاع گوشه‌ها</string>
     <string name="about_label">درباره</string>
     <string name="app_info_drop_target_label">اطلاعات برنامه</string>
-    <string name="debug_restart_launcher">راه‌اندازی مجدد Lawnchair</string>
+    <string name="debug_restart_launcher">راه‌اندازی مجدد دستیار</string>
     <string name="experimental_features_label">قابلیت‌های آزمایشی</string>
     <!-- Experimental features -->
     <string name="font_picker_label">شخصی‌سازی قلم</string>
@@ -171,7 +171,7 @@
     Notifications
 
     -->
-    <string name="set_default_launcher_tip">برای دسترسی به میانبرها و ویژگی‌های اضافی، Lawnchair را به عنوان راه‌انداز پیش‌فرض خود تنظیم کنید</string>
+    <string name="set_default_launcher_tip">برای دسترسی به میانبرها و ویژگی‌های اضافی، دستیار را به عنوان راه‌انداز پیش‌فرض خود تنظیم کنید</string>
     <string name="notification_dots">نشان اعلان‌ها</string>
     <string name="show_notification_count">نشان‌دادن تعداد اعلان‌ها</string>
     <string name="notification_dots_color">رنگ نشان اعلان‌ها</string>
@@ -344,7 +344,7 @@
     <string name="event_provider_missing_notification_dots">برای استفاده از <xliff:g example="My Provider" id="providerName">%1$s</xliff:g>، نقاط اعلان را روشن کنید.</string>
     <!-- Toggle button for enabling Smartspace -->
     <string name="smartspace_widget_toggle_label">نشان دادن در صفحه ‌اصلی</string>
-    <string name="smartspace_widget_toggle_description">در یک نگاه را می‌توان به‌طور دستی با قرار دادن ابزارک Lawnchair به صفحه اصلی اضافه کرد</string>
+    <string name="smartspace_widget_toggle_description">در یک نگاه را می‌توان به‌طور دستی با قرار دادن ابزارک دستیار به صفحه اصلی اضافه کرد</string>
     <!-- List of available providers -->
     <string name="smartspace_mode_label">ارائه دهنده در یک نگاه</string>
     <string name="smartspace_mode_google">گوگل</string>
@@ -415,18 +415,18 @@
     <string name="gesture_handler_open_assistant">بازکردن دستیار</string>
     <string name="pick_app_for_gesture">انتخاب برنامه</string>
     <string name="dt2s_admin_hint_title">دسترسی ادمین نیاز است</string>
-    <string name="dt2s_admin_hint">برای استفاده از قابلیت خواب با دو ضربه، Lawnchair را به عنوان یک برنامه‌ی مدیرِ دستگاه بگذارید. بر روی باز کردن تنظیمات ضربه بزنید، سپس بر روی «فعال سازی این برنامه مدیر دستگاه» ضربه بزنید.</string>
+    <string name="dt2s_admin_hint">برای استفاده از قابلیت خواب با دو ضربه، دستیار را به عنوان یک برنامه‌ی مدیرِ دستگاه بگذارید. بر روی باز کردن تنظیمات ضربه بزنید، سپس بر روی «فعال سازی این برنامه مدیر دستگاه» ضربه بزنید.</string>
     <string name="dt2s_admin_warning">دو ضربه سریع برای خواب خاموش خواهد شد.</string>
     <string name="d2ts_recents_a11y_hint_title">فعال‌سازی سرویس دسترس‌پذیری</string>
-    <string name="dt2s_a11y_hint">برای استفاده از قابلیت خواب با دو ضربه، سرویس دسترسی به Lawnchair را روشن کنید. روی «بازکردن تنظیمات» ضربه بزنید، «Lawnchair» را انتخاب کنید و «استفاده از Lawnchair» را روشن کنید.\n\nLawnchair از روش «انجام عملکرد جهانی» برای انجام این عمل استفاده می‌کند. این یک مجوز حساس است که امکان نظارت بر برنامه های دیگر را فراهم می کند. با این حال، Lawnchair برای آن پیکربندی نشده است و هیچ رویدادی دریافت نمی‌کند.</string>
+    <string name="dt2s_a11y_hint">برای استفاده از قابلیت خواب با دو ضربه، سرویس دسترسی به دستیار را روشن کنید. روی «بازکردن تنظیمات» ضربه بزنید، «دستیار» را انتخاب کنید و «استفاده از دستیار» را روشن کنید.\n\nدستیار از روش «انجام عملکرد جهانی» برای انجام این عمل استفاده می‌کند. این یک مجوز حساس است که امکان نظارت بر برنامه های دیگر را فراهم می کند. با این حال، دستیار برای آن پیکربندی نشده است و هیچ رویدادی دریافت نمی‌کند.</string>
     <string name="dt2s_recents_warning_open_settings">بازکردن تنظیمات</string>
-    <string name="recents_a11y_hint">To use Open Recents screen, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="recents_a11y_hint">To use Open Recents screen, turn on the دستیار accessibility service. Tap \"Open settings\", select \"دستیار\" and turn on \"Use دستیار.\"\n\nدستیار uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, دستیار is not configured for that functionality and receives no events.</string>
     <!--
 
     Bug reporting
 
     -->
-    <string name="lawnchair_bug_report">گزارش مشکلات Lawnchair</string>
+    <string name="lawnchair_bug_report">گزارش مشکلات دستیار</string>
     <string name="crash_report_notif_title">%1$s خطا داد</string>
     <string name="action_upload_crash_report">ارسال گزارش خطا</string>
     <string name="action_upload_error">آپلود با خطا مواجه شد</string>
@@ -519,7 +519,7 @@
     <!-- Search providers -->
     <string name="search_provider_app_search">جستجو برنامه</string>
     <string name="search_provider_custom">شخصی</string>
-    <string name="search_provider_sponsored_description">%1$s و Lawnchair یک قرارداد سهم درآمد دارند.\n\nجستجو با %1$s به پشتیبانی از Lawnchair کمک می‌کند.</string>
+    <string name="search_provider_sponsored_description">%1$s و دستیار یک قرارداد سهم درآمد دارند.\n\nجستجو با %1$s به پشتیبانی از دستیار کمک می‌کند.</string>
     <string name="app_label">برنامه</string>
     <string name="website_label">وب‌سایت</string>
     <string name="qsb_search_provider_app_required">برنامه نیاز است</string>
@@ -552,7 +552,7 @@
     <string name="max_folder_columns">حداکثر ستون‌های پوشه‌</string>
     <string name="max_folder_rows">حداکثر ردیف پوشه</string>
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">These settings will be ignored as Lawnchair isn\'t set as the Recents screen provider</string>
+    <string name="quickswitch_ignored_warning">These settings will be ignored as دستیار isn\'t set as the Recents screen provider</string>
     <string name="quickstep_incompatible">یکپارچه سازی سیستم ناسازگار</string>
     <string name="quickstep_incompatible_description">دستگاه شما به گونه‌ای پیکربندی شده که ژست‌های حرکتی سیستم (معروف به Quickstep) توسط %1$s ارائه شده سازگار باشد، ولی این نسخه %1$s با اندروید شما سازگار نیست. برای ادامه استفاده از دستگاهتان، لطفاً به‌روزرسانی‌ %1$s را حذف نصب کنید یا %1$s را به‌عنوان ارائه‌دهنده اشاره سیستم غیرفعال کنید.</string>
     <string name="translucent_background">پس‌زمینه نیمه شفاف</string>

--- a/lawnchair/res/values-fa/strings.xml
+++ b/lawnchair/res/values-fa/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, دستیار
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-fi-rFI/strings.xml
+++ b/lawnchair/res/values-fi-rFI/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI -avustaja
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@
     <string name="time_weeks_ago">%dw</string>
     <string name="time_months_ago">%dmo</string>
     <string name="time_years_ago">%dy</string>
-    <string name="managed_by_lawnchair">Lawnchairin hallinnoima</string>
+    <string name="managed_by_lawnchair">AI -avustajain hallinnoima</string>
     <!-- When mentioning settings UI -->
     <string name="smartspace_preferences">Asetukset</string>
     <string name="settings_button_text">Kotiasetukset</string>
@@ -69,7 +69,7 @@
     <string name="title_change_settings">Muuta asetuksia</string>
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout AI -avustaja
 
     -->
     <string name="others_category_label">Muut</string>
@@ -114,7 +114,7 @@
     <string name="folders_filter_duplicates">Näytä vain yksi kappale jokaista sovellusta</string>
     <string name="my_folder_label">Minun kansioni</string>
     <!-- A11y description -->
-    <string name="accessibility_service_description">Suorittaakseen tiettyjä toimintoja (niin kuin lukitakseen puhelimesi) kun käytät jotain elettä, Lawnchair pitää asettaa saavutettavuussovellukseksi.\n\nLawnchair ei seuraa mitään käyttäjän toimintaa, vaikkakin kyseistä lupaa käytetään kaikille saavutettavuussovelluksille. Lawnchair hylkää kaikki tapahtumat, jotka käyttöjärjestelmä lähettää.\n\nJotta Lawnchair voisi lukita puhelimesi tai avata viimeisimpien sovellusten näkymän, se käyttää performGlobalAction saavutettavuuspalvelua.</string>
+    <string name="accessibility_service_description">Suorittaakseen tiettyjä toimintoja (niin kuin lukitakseen puhelimesi) kun käytät jotain elettä, AI -avustaja pitää asettaa saavutettavuussovellukseksi.\n\nAI -avustaja ei seuraa mitään käyttäjän toimintaa, vaikkakin kyseistä lupaa käytetään kaikille saavutettavuussovelluksille. AI -avustaja hylkää kaikki tapahtumat, jotka käyttöjärjestelmä lähettää.\n\nJotta AI -avustaja voisi lukita puhelimesi tai avata viimeisimpien sovellusten näkymän, se käyttää performGlobalAction saavutettavuuspalvelua.</string>
     <string name="x_with_y_count">%1$s (%2$d)</string>
     <string name="x_by_y">%1$d X %2$d</string>
     <string name="x_and_y">%1$s &amp; %2$s</string>
@@ -143,7 +143,7 @@
     <string name="quickstep_description">Tyhjennä kaikki -nappi, kulmien pyöreys</string>
     <string name="about_label">Tietoja</string>
     <string name="app_info_drop_target_label">Tietoa sovelluksesta</string>
-    <string name="debug_restart_launcher">Uudelleenkäynnistä Lawnchair</string>
+    <string name="debug_restart_launcher">Uudelleenkäynnistä AI -avustaja</string>
     <string name="experimental_features_label">Kokeelliset ominaisuudet</string>
     <!-- Experimental features -->
     <string name="font_picker_label">Fontin muokkaus</string>
@@ -171,7 +171,7 @@
     Notifications
 
     -->
-    <string name="set_default_launcher_tip">Päästäksesi käsiksi pikku alkeisiin ja muihin lisäominaisuuksiin, aseta Lawnchair oletusaloitusnäyttösovellukseksesi.</string>
+    <string name="set_default_launcher_tip">Päästäksesi käsiksi pikku alkeisiin ja muihin lisäominaisuuksiin, aseta AI -avustaja oletusaloitusnäyttösovellukseksesi.</string>
     <string name="notification_dots">Ilmoituspisteet</string>
     <string name="show_notification_count">Näytä ilmoitusten määrä</string>
     <string name="notification_dots_color">Ilmoituspisteen väri</string>
@@ -344,7 +344,7 @@
     <string name="event_provider_missing_notification_dots">To use <xliff:g example="My Provider" id="providerName">%1$s</xliff:g>, turn on Notification Dots.</string>
     <!-- Toggle button for enabling Smartspace -->
     <string name="smartspace_widget_toggle_label">Show on home screen</string>
-    <string name="smartspace_widget_toggle_description">At a Glance can be manually added to the home screen by placing the Lawnchair widget</string>
+    <string name="smartspace_widget_toggle_description">At a Glance can be manually added to the home screen by placing the AI -avustaja widget</string>
     <!-- List of available providers -->
     <string name="smartspace_mode_label">At a Glance provider</string>
     <string name="smartspace_mode_google">Google</string>
@@ -415,18 +415,18 @@
     <string name="gesture_handler_open_assistant">Open assistant</string>
     <string name="pick_app_for_gesture">Pick app</string>
     <string name="dt2s_admin_hint_title">Admin permissions required</string>
-    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set Lawnchair as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
+    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set AI -avustaja as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
     <string name="dt2s_admin_warning">Kaksoisnapautus lepotilaan tulee olemaan pois päältä.</string>
     <string name="d2ts_recents_a11y_hint_title">Turn on accessibility service</string>
-    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the AI -avustaja accessibility service. Tap \"Open settings\", select \"AI -avustaja\" and turn on \"Use AI -avustaja.\"\n\nAI -avustaja uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, AI -avustaja is not configured for that functionality and receives no events.</string>
     <string name="dt2s_recents_warning_open_settings">Open settings</string>
-    <string name="recents_a11y_hint">To use Open Recents screen, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="recents_a11y_hint">To use Open Recents screen, turn on the AI -avustaja accessibility service. Tap \"Open settings\", select \"AI -avustaja\" and turn on \"Use AI -avustaja.\"\n\nAI -avustaja uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, AI -avustaja is not configured for that functionality and receives no events.</string>
     <!--
 
     Bug reporting
 
     -->
-    <string name="lawnchair_bug_report">Lawnchair bug report</string>
+    <string name="lawnchair_bug_report">AI -avustaja bug report</string>
     <string name="crash_report_notif_title">%1$s crashed</string>
     <string name="action_upload_crash_report">Upload crash log</string>
     <string name="action_upload_error">Lähetys epäonnistui</string>
@@ -519,7 +519,7 @@
     <!-- Search providers -->
     <string name="search_provider_app_search">App search</string>
     <string name="search_provider_custom">Mukautettu</string>
-    <string name="search_provider_sponsored_description">%1$s and Lawnchair have a revenue share agreement.\n\nSearching with %1$s helps support Lawnchair.</string>
+    <string name="search_provider_sponsored_description">%1$s and AI -avustaja have a revenue share agreement.\n\nSearching with %1$s helps support AI -avustaja.</string>
     <string name="app_label">Sovellus</string>
     <string name="website_label">Sivusto</string>
     <string name="qsb_search_provider_app_required">App required</string>
@@ -552,7 +552,7 @@
     <string name="max_folder_columns">Maximum folder columns</string>
     <string name="max_folder_rows">Maximum folder rows</string>
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">These settings will be ignored as Lawnchair isn\'t set as the Recents screen provider</string>
+    <string name="quickswitch_ignored_warning">These settings will be ignored as AI -avustaja isn\'t set as the Recents screen provider</string>
     <string name="quickstep_incompatible">Incompatible system integration</string>
     <string name="quickstep_incompatible_description">Your device is configured to have system gestures (known as Quickstep) provided by %1$s, but this version of %1$s isn\'t compatible with your Android version. To continue using your device, please uninstall %1$s updates or disable %1$s as a system gesture provider.</string>
     <string name="translucent_background">Translucent background</string>

--- a/lawnchair/res/values-fi/strings.xml
+++ b/lawnchair/res/values-fi/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI -avustaja
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-fil-rPH/strings.xml
+++ b/lawnchair/res/values-fil-rPH/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, Katulong ng AI
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@
     <string name="time_weeks_ago">%dl</string>
     <string name="time_months_ago">%db</string>
     <string name="time_years_ago">%dt</string>
-    <string name="managed_by_lawnchair">Pinamamahalaan ng Lawnchair</string>
+    <string name="managed_by_lawnchair">Pinamamahalaan ng Katulong ng AI</string>
     <!-- When mentioning settings UI -->
     <string name="smartspace_preferences">Mga Kagustuhan</string>
     <string name="settings_button_text">Settings ng Home</string>
@@ -69,7 +69,7 @@
     <string name="title_change_settings">Baguhin ang Mga Setting</string>
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout Katulong ng AI
 
     -->
     <string name="others_category_label">Iba pa</string>
@@ -114,7 +114,7 @@
     <string name="folders_filter_duplicates">Only show unique apps</string>
     <string name="my_folder_label">Baguhin ang folder</string>
     <!-- A11y description -->
-    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, Lawnchair uses the performGlobalAction Accessibility service.</string>
+    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, Katulong ng AI requires accessibility access.\n\nKatulong ng AI doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Katulong ng AI discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, Katulong ng AI uses the performGlobalAction Accessibility service.</string>
     <string name="x_with_y_count">%1$s (%2$d)</string>
     <string name="x_by_y">%1$d x %2$d</string>
     <string name="x_and_y">%1$s at %2$s</string>
@@ -171,7 +171,7 @@
     Notifications
 
     -->
-    <string name="set_default_launcher_tip">To access shortcuts and additional features, set Lawnchair as your default launcher</string>
+    <string name="set_default_launcher_tip">To access shortcuts and additional features, set Katulong ng AI as your default launcher</string>
     <string name="notification_dots">Mga tuldok ng abiso</string>
     <string name="show_notification_count">Show notification counter</string>
     <string name="notification_dots_color">Kulay ng tuldok ng abiso</string>
@@ -344,7 +344,7 @@
     <string name="event_provider_missing_notification_dots">Upang gamitin ang <xliff:g example="My Provider" id="providerName">%1$s</xliff:g>, paganahin ang mga Tuldok ng Abiso.</string>
     <!-- Toggle button for enabling Smartspace -->
     <string name="smartspace_widget_toggle_label">Show on home screen</string>
-    <string name="smartspace_widget_toggle_description">At a Glance can be manually added to the home screen by placing the Lawnchair widget</string>
+    <string name="smartspace_widget_toggle_description">At a Glance can be manually added to the home screen by placing the Katulong ng AI widget</string>
     <!-- List of available providers -->
     <string name="smartspace_mode_label">At a Glance provider</string>
     <string name="smartspace_mode_google">Google</string>
@@ -415,18 +415,18 @@
     <string name="gesture_handler_open_assistant">Open assistant</string>
     <string name="pick_app_for_gesture">Pick app</string>
     <string name="dt2s_admin_hint_title">Admin permissions required</string>
-    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set Lawnchair as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
+    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set Katulong ng AI as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
     <string name="dt2s_admin_warning">Mamamatay ang Double-Tap para Mamatay ang Device.</string>
     <string name="d2ts_recents_a11y_hint_title">Turn on accessibility service</string>
-    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the Katulong ng AI accessibility service. Tap \"Open settings\", select \"Katulong ng AI\" and turn on \"Use Katulong ng AI.\"\n\nKatulong ng AI uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Katulong ng AI is not configured for that functionality and receives no events.</string>
     <string name="dt2s_recents_warning_open_settings">Open settings</string>
-    <string name="recents_a11y_hint">To use Open Recents screen, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="recents_a11y_hint">To use Open Recents screen, turn on the Katulong ng AI accessibility service. Tap \"Open settings\", select \"Katulong ng AI\" and turn on \"Use Katulong ng AI.\"\n\nKatulong ng AI uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Katulong ng AI is not configured for that functionality and receives no events.</string>
     <!--
 
     Bug reporting
 
     -->
-    <string name="lawnchair_bug_report">Lawnchair bug report</string>
+    <string name="lawnchair_bug_report">Katulong ng AI bug report</string>
     <string name="crash_report_notif_title">%1$s crashed</string>
     <string name="action_upload_crash_report">Upload crash log</string>
     <string name="action_upload_error">Nabigo ang pag-upload</string>
@@ -519,7 +519,7 @@
     <!-- Search providers -->
     <string name="search_provider_app_search">App search</string>
     <string name="search_provider_custom">Pasadya</string>
-    <string name="search_provider_sponsored_description">%1$s and Lawnchair have a revenue share agreement.\n\nSearching with %1$s helps support Lawnchair.</string>
+    <string name="search_provider_sponsored_description">%1$s and Katulong ng AI have a revenue share agreement.\n\nSearching with %1$s helps support Katulong ng AI.</string>
     <string name="app_label">App</string>
     <string name="website_label">Website</string>
     <string name="qsb_search_provider_app_required">App required</string>
@@ -552,7 +552,7 @@
     <string name="max_folder_columns">Pinakamataas na bilang ng mga hanay</string>
     <string name="max_folder_rows">Pinakamataas na bilang ng mga hilera</string>
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">These settings will be ignored as Lawnchair isn\'t set as the Recents screen provider</string>
+    <string name="quickswitch_ignored_warning">These settings will be ignored as Katulong ng AI isn\'t set as the Recents screen provider</string>
     <string name="quickstep_incompatible">Incompatible system integration</string>
     <string name="quickstep_incompatible_description">Your device is configured to have system gestures (known as Quickstep) provided by %1$s, but this version of %1$s isn\'t compatible with your Android version. To continue using your device, please uninstall %1$s updates or disable %1$s as a system gesture provider.</string>
     <string name="translucent_background">Translucent background</string>

--- a/lawnchair/res/values-fr-rCA/strings.xml
+++ b/lawnchair/res/values-fr-rCA/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, Assistant d'IA
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-fr-rFR/strings.xml
+++ b/lawnchair/res/values-fr-rFR/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, Assistant d'IA
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@
     <string name="time_weeks_ago">%d sem.</string>
     <string name="time_months_ago">%d m.</string>
     <string name="time_years_ago">%d a</string>
-    <string name="managed_by_lawnchair">Gérée par Lawnchair</string>
+    <string name="managed_by_lawnchair">Gérée par Assistant d'IA</string>
     <!-- When mentioning settings UI -->
     <string name="smartspace_preferences">Préférences</string>
     <string name="settings_button_text">Paramètres de l\'accueil</string>
@@ -69,7 +69,7 @@
     <string name="title_change_settings">Modifier les paramètres</string>
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout Assistant d'IA
 
     -->
     <string name="others_category_label">Autres</string>
@@ -114,7 +114,7 @@
     <string name="folders_filter_duplicates">Afficher seulement les applis uniques</string>
     <string name="my_folder_label">Mon dossier</string>
     <!-- A11y description -->
-    <string name="accessibility_service_description">Pour effectuer certaines actions (telles que verrouiller votre téléphone) en un seul geste, Lawnchair a besoin des droits d\'accessibilité.\n\nMalgré que le privilège est accordé de force à tous les services d\'accessibilité, Lawnchair n\'observe pas les actions de l\'utilisateur et ignore tous les événements envoyés par le système.\n\nAfin de verrouiller votre téléphone ou ouvrir l\'écran Récents, Lawnchair utilise le service d\'accessibilité performGlobalAction.</string>
+    <string name="accessibility_service_description">Pour effectuer certaines actions (telles que verrouiller votre téléphone) en un seul geste, Assistant d'IA a besoin des droits d\'accessibilité.\n\nMalgré que le privilège est accordé de force à tous les services d\'accessibilité, Assistant d'IA n\'observe pas les actions de l\'utilisateur et ignore tous les événements envoyés par le système.\n\nAfin de verrouiller votre téléphone ou ouvrir l\'écran Récents, Assistant d'IA utilise le service d\'accessibilité performGlobalAction.</string>
     <string name="x_with_y_count">%1$s (%2$d)</string>
     <string name="x_by_y">%1$d x %2$d</string>
     <string name="x_and_y">%1$s et %2$s</string>
@@ -143,7 +143,7 @@
     <string name="quickstep_description">Bouton Tout effacer, rayon d\'angle</string>
     <string name="about_label">À propos</string>
     <string name="app_info_drop_target_label">Infos sur l\'appli</string>
-    <string name="debug_restart_launcher">Redémarrer Lawnchair</string>
+    <string name="debug_restart_launcher">Redémarrer Assistant d'IA</string>
     <string name="experimental_features_label">Fonctionnalités expérimentales</string>
     <!-- Experimental features -->
     <string name="font_picker_label">Personnalisation de la police</string>
@@ -171,7 +171,7 @@
     Notifications
 
     -->
-    <string name="set_default_launcher_tip">Pour accéder aux raccourcis et à plus de fonctionnalités, définissez Lawnchair en tant que lanceur d\'applications par défaut</string>
+    <string name="set_default_launcher_tip">Pour accéder aux raccourcis et à plus de fonctionnalités, définissez Assistant d'IA en tant que lanceur d\'applications par défaut</string>
     <string name="notification_dots">Pastilles de notification</string>
     <string name="show_notification_count">Afficher le compteur de notifications</string>
     <string name="notification_dots_color">Couleur des pastilles de notification</string>
@@ -344,7 +344,7 @@
     <string name="event_provider_missing_notification_dots">Pour pouvoir utiliser <xliff:g example="My Provider" id="providerName">%1$s</xliff:g>, activez les pastilles de notification.</string>
     <!-- Toggle button for enabling Smartspace -->
     <string name="smartspace_widget_toggle_label">Afficher sur l\'écran d\'accueil</string>
-    <string name="smartspace_widget_toggle_description">Aperçu peut être ajouté manuellement à l\'écran d\'accueil en plaçant le widget Lawnchair</string>
+    <string name="smartspace_widget_toggle_description">Aperçu peut être ajouté manuellement à l\'écran d\'accueil en plaçant le widget Assistant d'IA</string>
     <!-- List of available providers -->
     <string name="smartspace_mode_label">Fournisseur d\'Aperçu</string>
     <string name="smartspace_mode_google">Google</string>
@@ -415,18 +415,18 @@
     <string name="gesture_handler_open_assistant">Ouvrir l\'assistant</string>
     <string name="pick_app_for_gesture">Sélectionnez une appli</string>
     <string name="dt2s_admin_hint_title">Autorisations d\'administration requises</string>
-    <string name="dt2s_admin_hint">Pour mettre en veille votre appareil à l\'aide d\'un double appui, définissez Lawnchair comme appli d\'administration de l\'appareil. Appuyez sur « Ouvrir les paramètres » puis appuyez sur « Activer l\'appli d\'administration de cet appareil. »</string>
+    <string name="dt2s_admin_hint">Pour mettre en veille votre appareil à l\'aide d\'un double appui, définissez Assistant d'IA comme appli d\'administration de l\'appareil. Appuyez sur « Ouvrir les paramètres » puis appuyez sur « Activer l\'appli d\'administration de cet appareil. »</string>
     <string name="dt2s_admin_warning">Vous ne pourrez plus mettre en veille votre appareil à l\'aide d\'un double appui.</string>
     <string name="d2ts_recents_a11y_hint_title">Activez le service d\'accessibilité</string>
-    <string name="dt2s_a11y_hint">Pour mettre en veille votre appareil avec un double appui, activez le service d\'accessibilité Lawnchair. Appuyez sur « Ouvrir les paramètres », sélectionnez « Lawnchair » et activez « Utiliser Lawnchair ».\n\nLawnchair utilise la méthode d\'accessibilité `performGlobalAction`. Il s\'agit d\'une autorisation sensible qui permet de suivre le comportement des autres applis, mais Lawnchair n\'est pas configuré de manière à utiliser ces fonctionnalités et ne reçoit donc aucun événement.</string>
+    <string name="dt2s_a11y_hint">Pour mettre en veille votre appareil avec un double appui, activez le service d\'accessibilité Assistant d'IA. Appuyez sur « Ouvrir les paramètres », sélectionnez « Assistant d'IA » et activez « Utiliser Assistant d'IA ».\n\nAssistant d'IA utilise la méthode d\'accessibilité `performGlobalAction`. Il s\'agit d\'une autorisation sensible qui permet de suivre le comportement des autres applis, mais Assistant d'IA n\'est pas configuré de manière à utiliser ces fonctionnalités et ne reçoit donc aucun événement.</string>
     <string name="dt2s_recents_warning_open_settings">Ouvrir les paramètres</string>
-    <string name="recents_a11y_hint">Pour utiliser Ouvrir l\'écran Récents, activez le service d\'accessibilité Lawnchair. Appuyez sur « Ouvrir les paramètres », sélectionnez « Lawnchair » et activez « Utiliser Lawnchair ».\n\nLawnchair utilise la méthode d\'accessibilité `performGlobalAction`. Il s\'agit d\'une autorisation sensible qui permet de suivre le comportement des autres applis, mais Lawnchair n\'est pas configuré de manière à utiliser ces fonctionnalités et ne reçoit donc aucun événement.</string>
+    <string name="recents_a11y_hint">Pour utiliser Ouvrir l\'écran Récents, activez le service d\'accessibilité Assistant d'IA. Appuyez sur « Ouvrir les paramètres », sélectionnez « Assistant d'IA » et activez « Utiliser Assistant d'IA ».\n\nAssistant d'IA utilise la méthode d\'accessibilité `performGlobalAction`. Il s\'agit d\'une autorisation sensible qui permet de suivre le comportement des autres applis, mais Assistant d'IA n\'est pas configuré de manière à utiliser ces fonctionnalités et ne reçoit donc aucun événement.</string>
     <!--
 
     Bug reporting
 
     -->
-    <string name="lawnchair_bug_report">Signalement de bug Lawnchair</string>
+    <string name="lawnchair_bug_report">Signalement de bug Assistant d'IA</string>
     <string name="crash_report_notif_title">%1$s a planté</string>
     <string name="action_upload_crash_report">Envoyer le journal de plantage</string>
     <string name="action_upload_error">Échec de l\'envoi</string>
@@ -519,7 +519,7 @@
     <!-- Search providers -->
     <string name="search_provider_app_search">Recherche d\'applis</string>
     <string name="search_provider_custom">Personnalisé</string>
-    <string name="search_provider_sponsored_description">%1$s et Lawnchair ont signé un accord de partage des revenus.\n\nEn effectuant vos recherches avec %1$s, vous soutenez Lawnchair.</string>
+    <string name="search_provider_sponsored_description">%1$s et Assistant d'IA ont signé un accord de partage des revenus.\n\nEn effectuant vos recherches avec %1$s, vous soutenez Assistant d'IA.</string>
     <string name="app_label">Application</string>
     <string name="website_label">Site Web</string>
     <string name="qsb_search_provider_app_required">Appli requise</string>
@@ -552,7 +552,7 @@
     <string name="max_folder_columns">Colonnes max. dans les dossiers</string>
     <string name="max_folder_rows">Lignes max. dans les dossiers</string>
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">Ces paramètres seront ignorés car Lawnchair n\'est pas défini comme fournisseur d\'écran Récents</string>
+    <string name="quickswitch_ignored_warning">Ces paramètres seront ignorés car Assistant d'IA n\'est pas défini comme fournisseur d\'écran Récents</string>
     <string name="quickstep_incompatible">Intégration système incompatible</string>
     <string name="quickstep_incompatible_description">Votre appareil est configuré pour que la navigation par gestes (appelée Quickstep) soit fournie par %1$s, mais la version installée n\'est pas compatible avec votre version d\'Android. Pour continuer à utiliser votre appareil, désinstallez les mises à jour de %1$s ou désactivez-le en tant que fournisseur système de navigation par gestes.</string>
     <string name="translucent_background">Arrière-plan translucide</string>

--- a/lawnchair/res/values-fr/strings.xml
+++ b/lawnchair/res/values-fr/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, Assistant d'IA
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-gl-rES/strings.xml
+++ b/lawnchair/res/values-gl-rES/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI asistente
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@
     <string name="time_weeks_ago">%d semanas</string>
     <string name="time_months_ago">%d meses</string>
     <string name="time_years_ago">%d anos</string>
-    <string name="managed_by_lawnchair">Xestionado por Lawnchair</string>
+    <string name="managed_by_lawnchair">Xestionado por AI asistente</string>
     <!-- When mentioning settings UI -->
     <string name="smartspace_preferences">Preferencias</string>
     <string name="settings_button_text">Configuración do lanzador</string>
@@ -69,7 +69,7 @@
     <string name="title_change_settings">Cambiar configuración</string>
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout AI asistente
 
     -->
     <string name="others_category_label">Outros</string>
@@ -114,7 +114,7 @@
     <string name="folders_filter_duplicates">Só amosar aplicacións únicas</string>
     <string name="my_folder_label">O meu cartafol</string>
     <!-- A11y description -->
-    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, Lawnchair uses the performGlobalAction Accessibility service.</string>
+    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, AI asistente requires accessibility access.\n\nAI asistente doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. AI asistente discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, AI asistente uses the performGlobalAction Accessibility service.</string>
     <string name="x_with_y_count">%1$s (%2$d)</string>
     <string name="x_by_y">%1$d × %2$d</string>
     <string name="x_and_y">%1$s &amp; %2$s</string>
@@ -143,7 +143,7 @@
     <string name="quickstep_description">Clear All button, corner radius</string>
     <string name="about_label">Acerca de</string>
     <string name="app_info_drop_target_label">Información da aplicación</string>
-    <string name="debug_restart_launcher">Reiniciar Lawnchair</string>
+    <string name="debug_restart_launcher">Reiniciar AI asistente</string>
     <string name="experimental_features_label">Funcións experimentais</string>
     <!-- Experimental features -->
     <string name="font_picker_label">Personalización de fonte</string>
@@ -171,7 +171,7 @@
     Notifications
 
     -->
-    <string name="set_default_launcher_tip">To access shortcuts and additional features, set Lawnchair as your default launcher</string>
+    <string name="set_default_launcher_tip">To access shortcuts and additional features, set AI asistente as your default launcher</string>
     <string name="notification_dots">Puntos de notificación</string>
     <string name="show_notification_count">Show notification counter</string>
     <string name="notification_dots_color">Cor do punto de notificación</string>
@@ -344,7 +344,7 @@
     <string name="event_provider_missing_notification_dots">To use <xliff:g example="My Provider" id="providerName">%1$s</xliff:g>, turn on Notification Dots.</string>
     <!-- Toggle button for enabling Smartspace -->
     <string name="smartspace_widget_toggle_label">Show on home screen</string>
-    <string name="smartspace_widget_toggle_description">At a Glance can be manually added to the home screen by placing the Lawnchair widget</string>
+    <string name="smartspace_widget_toggle_description">At a Glance can be manually added to the home screen by placing the AI asistente widget</string>
     <!-- List of available providers -->
     <string name="smartspace_mode_label">At a Glance provider</string>
     <string name="smartspace_mode_google">Google</string>
@@ -415,18 +415,18 @@
     <string name="gesture_handler_open_assistant">Open assistant</string>
     <string name="pick_app_for_gesture">Pick app</string>
     <string name="dt2s_admin_hint_title">Admin permissions required</string>
-    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set Lawnchair as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
+    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set AI asistente as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
     <string name="dt2s_admin_warning">Double-Tap to Sleep will be turned off.</string>
     <string name="d2ts_recents_a11y_hint_title">Turn on accessibility service</string>
-    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the AI asistente accessibility service. Tap \"Open settings\", select \"AI asistente\" and turn on \"Use AI asistente.\"\n\nAI asistente uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, AI asistente is not configured for that functionality and receives no events.</string>
     <string name="dt2s_recents_warning_open_settings">Open settings</string>
-    <string name="recents_a11y_hint">To use Open Recents screen, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="recents_a11y_hint">To use Open Recents screen, turn on the AI asistente accessibility service. Tap \"Open settings\", select \"AI asistente\" and turn on \"Use AI asistente.\"\n\nAI asistente uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, AI asistente is not configured for that functionality and receives no events.</string>
     <!--
 
     Bug reporting
 
     -->
-    <string name="lawnchair_bug_report">Lawnchair bug report</string>
+    <string name="lawnchair_bug_report">AI asistente bug report</string>
     <string name="crash_report_notif_title">%1$s crashed</string>
     <string name="action_upload_crash_report">Upload crash log</string>
     <string name="action_upload_error">Upload failed</string>
@@ -519,7 +519,7 @@
     <!-- Search providers -->
     <string name="search_provider_app_search">App search</string>
     <string name="search_provider_custom">Custom</string>
-    <string name="search_provider_sponsored_description">%1$s and Lawnchair have a revenue share agreement.\n\nSearching with %1$s helps support Lawnchair.</string>
+    <string name="search_provider_sponsored_description">%1$s and AI asistente have a revenue share agreement.\n\nSearching with %1$s helps support AI asistente.</string>
     <string name="app_label">App</string>
     <string name="website_label">Website</string>
     <string name="qsb_search_provider_app_required">App required</string>
@@ -552,7 +552,7 @@
     <string name="max_folder_columns">Maximum folder columns</string>
     <string name="max_folder_rows">Maximum folder rows</string>
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">These settings will be ignored as Lawnchair isn\'t set as the Recents screen provider</string>
+    <string name="quickswitch_ignored_warning">These settings will be ignored as AI asistente isn\'t set as the Recents screen provider</string>
     <string name="quickstep_incompatible">Incompatible system integration</string>
     <string name="quickstep_incompatible_description">Your device is configured to have system gestures (known as Quickstep) provided by %1$s, but this version of %1$s isn\'t compatible with your Android version. To continue using your device, please uninstall %1$s updates or disable %1$s as a system gesture provider.</string>
     <string name="translucent_background">Translucent background</string>

--- a/lawnchair/res/values-gl/strings.xml
+++ b/lawnchair/res/values-gl/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI asistente
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-gu/strings.xml
+++ b/lawnchair/res/values-gu/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, એ.આઈ. મદદનીશ
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-he/strings.xml
+++ b/lawnchair/res/values-he/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, עוזר AI
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -74,10 +74,10 @@
         <item quantity="other">%1$d Apps</item>
     </plurals>
     <string name="dt2s_admin_hint_title">Admin permission required</string>
-    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set Lawnchair as a device admin app. Tap Open Settings, then tap “Activate this device admin app.”</string>
+    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set עוזר AI as a device admin app. Tap Open Settings, then tap “Activate this device admin app.”</string>
     <string name="dt2s_admin_warning">Double Tap to Sleep will be disabled.</string>
     <string name="dt2s_a11y_hint_title">Accessibility service required</string>
-    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the Lawnchair accessibility service. Tap Open Settings, then select Lawnchair and turn on Use Lawnchair.</string>
+    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the עוזר AI accessibility service. Tap Open Settings, then select עוזר AI and turn on Use עוזר AI.</string>
     <string name="dt2s_warning_open_settings">פתיחת הגדרות</string>
     <string name="minus_one_enable">פיד</string>
     <string name="minus_one_unavailable">ההזנה אינה מותקנת.</string>
@@ -107,7 +107,7 @@
     <string name="missing_notification_access_description">נדרשת גישה להתראות.</string>
     <string name="msg_missing_notification_access">To use Notification Dots, grant <xliff:g id="name" example="My App">%1$s</xliff:g> access to notifications.</string>
     <string name="title_change_settings">שינוי הגדרות</string>
-    <string name="debug_restart_launcher">Restart Lawnchair</string>
+    <string name="debug_restart_launcher">Restart עוזר AI</string>
     <string name="pref_fonts_missing_font">פונט לא נמצא.</string>
     <string name="font_variant_italic">נטוי</string>
     <string name="font_weight_thin">דק</string>
@@ -146,7 +146,7 @@
     <string name="dynamic">Dynamic</string>
     <string name="all_apps_search_market_message">Search for More Apps</string>
     <string name="show_app_search_bar">הצגת סרגל חיפוש</string>
-    <string name="lawnchair_bug_report">Lawnchair Bug Report</string>
+    <string name="lawnchair_bug_report">עוזר AI Bug Report</string>
     <string name="crash_report_notif_title">%1$s Crashed</string>
     <string name="action_copy_link">העתקת קישור</string>
     <string name="action_copy">העתקה</string>

--- a/lawnchair/res/values-hi-rIN/strings.xml
+++ b/lawnchair/res/values-hi-rIN/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, एआई सहायक
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@
     <string name="time_weeks_ago">%dw</string>
     <string name="time_months_ago">%dmo</string>
     <string name="time_years_ago">%dy</string>
-    <string name="managed_by_lawnchair">Lawnchair द्वारा प्रबंधित</string>
+    <string name="managed_by_lawnchair">एआई सहायक द्वारा प्रबंधित</string>
     <!-- When mentioning settings UI -->
     <string name="smartspace_preferences">पसंद</string>
     <string name="settings_button_text">होम सेटिंग्स</string>
@@ -69,7 +69,7 @@
     <string name="title_change_settings">सेटिंग्स परिवर्तित करना</string>
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout एआई सहायक
 
     -->
     <string name="others_category_label">Others</string>
@@ -114,7 +114,7 @@
     <string name="folders_filter_duplicates">Only show unique apps</string>
     <string name="my_folder_label">My folder</string>
     <!-- A11y description -->
-    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, Lawnchair uses the performGlobalAction Accessibility service.</string>
+    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, एआई सहायक requires accessibility access.\n\nएआई सहायक doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. एआई सहायक discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, एआई सहायक uses the performGlobalAction Accessibility service.</string>
     <string name="x_with_y_count">%1$s (%2$d)</string>
     <string name="x_by_y">%1$d x %2$d</string>
     <string name="x_and_y">%1$s और %2$s</string>
@@ -171,7 +171,7 @@
     Notifications
 
     -->
-    <string name="set_default_launcher_tip">To access shortcuts and additional features, set Lawnchair as your default launcher</string>
+    <string name="set_default_launcher_tip">To access shortcuts and additional features, set एआई सहायक as your default launcher</string>
     <string name="notification_dots">Notification dots</string>
     <string name="show_notification_count">Show notification counter</string>
     <string name="notification_dots_color">Notification dot color</string>
@@ -344,7 +344,7 @@
     <string name="event_provider_missing_notification_dots">To use <xliff:g example="My Provider" id="providerName">%1$s</xliff:g>, turn on Notification Dots.</string>
     <!-- Toggle button for enabling Smartspace -->
     <string name="smartspace_widget_toggle_label">Show on home screen</string>
-    <string name="smartspace_widget_toggle_description">At a Glance can be manually added to the home screen by placing the Lawnchair widget</string>
+    <string name="smartspace_widget_toggle_description">At a Glance can be manually added to the home screen by placing the एआई सहायक widget</string>
     <!-- List of available providers -->
     <string name="smartspace_mode_label">At a Glance provider</string>
     <string name="smartspace_mode_google">गूगल</string>
@@ -415,18 +415,18 @@
     <string name="gesture_handler_open_assistant">Open assistant</string>
     <string name="pick_app_for_gesture">Pick app</string>
     <string name="dt2s_admin_hint_title">Admin permissions required</string>
-    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set Lawnchair as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
+    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set एआई सहायक as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
     <string name="dt2s_admin_warning">सोने के लिए डबल-टैप करना बंद कर दिया जाएगा।</string>
     <string name="d2ts_recents_a11y_hint_title">Turn on accessibility service</string>
-    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the एआई सहायक accessibility service. Tap \"Open settings\", select \"एआई सहायक\" and turn on \"Use एआई सहायक.\"\n\nएआई सहायक uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, एआई सहायक is not configured for that functionality and receives no events.</string>
     <string name="dt2s_recents_warning_open_settings">Open settings</string>
-    <string name="recents_a11y_hint">To use Open Recents screen, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="recents_a11y_hint">To use Open Recents screen, turn on the एआई सहायक accessibility service. Tap \"Open settings\", select \"एआई सहायक\" and turn on \"Use एआई सहायक.\"\n\nएआई सहायक uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, एआई सहायक is not configured for that functionality and receives no events.</string>
     <!--
 
     Bug reporting
 
     -->
-    <string name="lawnchair_bug_report">Lawnchair bug report</string>
+    <string name="lawnchair_bug_report">एआई सहायक bug report</string>
     <string name="crash_report_notif_title">%1$s crashed</string>
     <string name="action_upload_crash_report">Upload crash log</string>
     <string name="action_upload_error">Dogbin में अपलोड करना विफल हुआ</string>
@@ -519,7 +519,7 @@
     <!-- Search providers -->
     <string name="search_provider_app_search">App search</string>
     <string name="search_provider_custom">रुचि अनुसार</string>
-    <string name="search_provider_sponsored_description">%1$s and Lawnchair have a revenue share agreement.\n\nSearching with %1$s helps support Lawnchair.</string>
+    <string name="search_provider_sponsored_description">%1$s and एआई सहायक have a revenue share agreement.\n\nSearching with %1$s helps support एआई सहायक.</string>
     <string name="app_label">ऐप</string>
     <string name="website_label">वेबसाइट</string>
     <string name="qsb_search_provider_app_required">App required</string>
@@ -552,7 +552,7 @@
     <string name="max_folder_columns">Maximum folder columns</string>
     <string name="max_folder_rows">Maximum folder rows</string>
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">These settings will be ignored as Lawnchair isn\'t set as the Recents screen provider</string>
+    <string name="quickswitch_ignored_warning">These settings will be ignored as एआई सहायक isn\'t set as the Recents screen provider</string>
     <string name="quickstep_incompatible">Incompatible system integration</string>
     <string name="quickstep_incompatible_description">Your device is configured to have system gestures (known as Quickstep) provided by %1$s, but this version of %1$s isn\'t compatible with your Android version. To continue using your device, please uninstall %1$s updates or disable %1$s as a system gesture provider.</string>
     <string name="translucent_background">Translucent background</string>

--- a/lawnchair/res/values-hi/strings.xml
+++ b/lawnchair/res/values-hi/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, एआई सहायक
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-hr-rHR/strings.xml
+++ b/lawnchair/res/values-hr-rHR/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI pomoćnik
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@
     <string name="time_weeks_ago">%dw</string>
     <string name="time_months_ago">%dmo</string>
     <string name="time_years_ago">%dy</string>
-    <string name="managed_by_lawnchair">Ovime upravlja Lawnchair</string>
+    <string name="managed_by_lawnchair">Ovime upravlja AI pomoćnik</string>
     <!-- When mentioning settings UI -->
     <string name="smartspace_preferences">Postavke</string>
     <string name="settings_button_text">Postavke pokretača</string>
@@ -69,7 +69,7 @@
     <string name="title_change_settings">Promijeni postavke</string>
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout AI pomoćnik
 
     -->
     <string name="others_category_label">Ostalo</string>
@@ -114,7 +114,7 @@
     <string name="folders_filter_duplicates">Samo prikaži određene aplikacije</string>
     <string name="my_folder_label">Moja mapa</string>
     <!-- A11y description -->
-    <string name="accessibility_service_description">Da izvedete određene stavke (poput zaključavanja zaslona) dok izvodite gestu, Lawnchair-u je potreban pristup postavki za pristupačnost.\n\nLawnchair ne prati korisničke radnje, iako je odobrenje za to potrebno za sve usluge pristupačnosti. Lawnchair odbija svaki događaj poslan od sustava.\n\nDa zaključate zaslon, ili da otvorite Nedavno, Lawnchair koristi pristupačnu uslugu preformGlobalAction.</string>
+    <string name="accessibility_service_description">Da izvedete određene stavke (poput zaključavanja zaslona) dok izvodite gestu, AI pomoćnik-u je potreban pristup postavki za pristupačnost.\n\nAI pomoćnik ne prati korisničke radnje, iako je odobrenje za to potrebno za sve usluge pristupačnosti. AI pomoćnik odbija svaki događaj poslan od sustava.\n\nDa zaključate zaslon, ili da otvorite Nedavno, AI pomoćnik koristi pristupačnu uslugu preformGlobalAction.</string>
     <string name="x_with_y_count">%1$s (%2$d)</string>
     <string name="x_by_y">%1$d x %2$d</string>
     <string name="x_and_y">%1$s &amp; %2$s</string>
@@ -143,7 +143,7 @@
     <string name="quickstep_description">Izbriši sve gumb, promjer kutova</string>
     <string name="about_label">O</string>
     <string name="app_info_drop_target_label">Informacije o aplikaciji</string>
-    <string name="debug_restart_launcher">Ponovno pokreni Lawnchair</string>
+    <string name="debug_restart_launcher">Ponovno pokreni AI pomoćnik</string>
     <string name="experimental_features_label">Eksperimentalne značajke</string>
     <!-- Experimental features -->
     <string name="font_picker_label">Uređivanje fontova</string>
@@ -171,7 +171,7 @@
     Notifications
 
     -->
-    <string name="set_default_launcher_tip">Za pristup prečacima i dodatnim značajkama, postavite Lawnchair kao zadani pokretač</string>
+    <string name="set_default_launcher_tip">Za pristup prečacima i dodatnim značajkama, postavite AI pomoćnik kao zadani pokretač</string>
     <string name="notification_dots">Točke obavijesti</string>
     <string name="show_notification_count">Prikaži broj obavijesti</string>
     <string name="notification_dots_color">Boja točke obavijesti</string>
@@ -344,7 +344,7 @@
     <string name="event_provider_missing_notification_dots">To use <xliff:g example="My Provider" id="providerName">%1$s</xliff:g>, turn on Notification Dots.</string>
     <!-- Toggle button for enabling Smartspace -->
     <string name="smartspace_widget_toggle_label">Show on home screen</string>
-    <string name="smartspace_widget_toggle_description">At a Glance can be manually added to the home screen by placing the Lawnchair widget</string>
+    <string name="smartspace_widget_toggle_description">At a Glance can be manually added to the home screen by placing the AI pomoćnik widget</string>
     <!-- List of available providers -->
     <string name="smartspace_mode_label">At a Glance provider</string>
     <string name="smartspace_mode_google">Google</string>
@@ -415,18 +415,18 @@
     <string name="gesture_handler_open_assistant">Open assistant</string>
     <string name="pick_app_for_gesture">Pick app</string>
     <string name="dt2s_admin_hint_title">Admin permissions required</string>
-    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set Lawnchair as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
+    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set AI pomoćnik as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
     <string name="dt2s_admin_warning">Double-Tap to Sleep will be turned off.</string>
     <string name="d2ts_recents_a11y_hint_title">Turn on accessibility service</string>
-    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the AI pomoćnik accessibility service. Tap \"Open settings\", select \"AI pomoćnik\" and turn on \"Use AI pomoćnik.\"\n\nAI pomoćnik uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, AI pomoćnik is not configured for that functionality and receives no events.</string>
     <string name="dt2s_recents_warning_open_settings">Open settings</string>
-    <string name="recents_a11y_hint">To use Open Recents screen, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="recents_a11y_hint">To use Open Recents screen, turn on the AI pomoćnik accessibility service. Tap \"Open settings\", select \"AI pomoćnik\" and turn on \"Use AI pomoćnik.\"\n\nAI pomoćnik uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, AI pomoćnik is not configured for that functionality and receives no events.</string>
     <!--
 
     Bug reporting
 
     -->
-    <string name="lawnchair_bug_report">Lawnchair bug report</string>
+    <string name="lawnchair_bug_report">AI pomoćnik bug report</string>
     <string name="crash_report_notif_title">%1$s crashed</string>
     <string name="action_upload_crash_report">Upload crash log</string>
     <string name="action_upload_error">Upload failed</string>
@@ -519,7 +519,7 @@
     <!-- Search providers -->
     <string name="search_provider_app_search">App search</string>
     <string name="search_provider_custom">Prilagođeno</string>
-    <string name="search_provider_sponsored_description">%1$s and Lawnchair have a revenue share agreement.\n\nSearching with %1$s helps support Lawnchair.</string>
+    <string name="search_provider_sponsored_description">%1$s and AI pomoćnik have a revenue share agreement.\n\nSearching with %1$s helps support AI pomoćnik.</string>
     <string name="app_label">App</string>
     <string name="website_label">Website</string>
     <string name="qsb_search_provider_app_required">App required</string>
@@ -553,7 +553,7 @@
     <string name="max_folder_columns">Maximum folder columns</string>
     <string name="max_folder_rows">Maximum folder rows</string>
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">These settings will be ignored as Lawnchair isn\'t set as the Recents screen provider</string>
+    <string name="quickswitch_ignored_warning">These settings will be ignored as AI pomoćnik isn\'t set as the Recents screen provider</string>
     <string name="quickstep_incompatible">Incompatible system integration</string>
     <string name="quickstep_incompatible_description">Your device is configured to have system gestures (known as Quickstep) provided by %1$s, but this version of %1$s isn\'t compatible with your Android version. To continue using your device, please uninstall %1$s updates or disable %1$s as a system gesture provider.</string>
     <string name="translucent_background">Translucent background</string>

--- a/lawnchair/res/values-hr/strings.xml
+++ b/lawnchair/res/values-hr/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI pomoćnik
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-hu-rHU/strings.xml
+++ b/lawnchair/res/values-hu-rHU/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI asszisztens
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@
     <string name="time_weeks_ago">%dw</string>
     <string name="time_months_ago">%dmo</string>
     <string name="time_years_ago">%dy</string>
-    <string name="managed_by_lawnchair">A Lawnchair által kezelve</string>
+    <string name="managed_by_lawnchair">A AI asszisztens által kezelve</string>
     <!-- When mentioning settings UI -->
     <string name="smartspace_preferences">Beállítások</string>
     <string name="settings_button_text">Kezdőoldal-beállítások</string>
@@ -69,7 +69,7 @@
     <string name="title_change_settings">Beállítások módosítása</string>
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout AI asszisztens
 
     -->
     <string name="others_category_label">Egyebek</string>
@@ -114,7 +114,7 @@
     <string name="folders_filter_duplicates">Csak az egyedi alkalmazások jelenjenek meg</string>
     <string name="my_folder_label">Mappáim</string>
     <!-- A11y description -->
-    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, Lawnchair uses the performGlobalAction Accessibility service.</string>
+    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, AI asszisztens requires accessibility access.\n\nAI asszisztens doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. AI asszisztens discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, AI asszisztens uses the performGlobalAction Accessibility service.</string>
     <string name="x_with_y_count">%1$s (%2$d)</string>
     <string name="x_by_y">%1$d × %2$d</string>
     <string name="x_and_y">%1$s és %2$s</string>
@@ -143,7 +143,7 @@
     <string name="quickstep_description">„Összes törlése” gomb, sarok sugara</string>
     <string name="about_label">Névjegy</string>
     <string name="app_info_drop_target_label">Alkalmazásinformáció</string>
-    <string name="debug_restart_launcher">A Lawnchair újraindítása</string>
+    <string name="debug_restart_launcher">A AI asszisztens újraindítása</string>
     <string name="experimental_features_label">Kísérleti funkciók</string>
     <!-- Experimental features -->
     <string name="font_picker_label">A betűkészlet testreszabása</string>
@@ -171,7 +171,7 @@
     Notifications
 
     -->
-    <string name="set_default_launcher_tip">A parancsikonok és a további funkciók eléréséhez állítsa be a Lawnchair-t alapértelmezettként</string>
+    <string name="set_default_launcher_tip">A parancsikonok és a további funkciók eléréséhez állítsa be a AI asszisztens-t alapértelmezettként</string>
     <string name="notification_dots">Értesítési pöttyök</string>
     <string name="show_notification_count">Legyen látható az értesítés-számláló</string>
     <string name="notification_dots_color">Az értesítési pöttyök színe</string>
@@ -344,7 +344,7 @@
     <string name="event_provider_missing_notification_dots">Kapcsolja be az Értesítési pöttyöket a <xliff:g example="My Provider" id="providerName">%1$s</xliff:g> használatához</string>
     <!-- Toggle button for enabling Smartspace -->
     <string name="smartspace_widget_toggle_label">Megjelenítés a Kezdőképernyőn</string>
-    <string name="smartspace_widget_toggle_description">Az \'Áttekintés\' manuálisan hozzáadható a Kezdőképernyőhöz a Lawnchair kisalkalmazás elhelyezésével</string>
+    <string name="smartspace_widget_toggle_description">Az \'Áttekintés\' manuálisan hozzáadható a Kezdőképernyőhöz a AI asszisztens kisalkalmazás elhelyezésével</string>
     <!-- List of available providers -->
     <string name="smartspace_mode_label">Az \'Áttekintés\' szolgáltatója</string>
     <string name="smartspace_mode_google">Google</string>
@@ -415,18 +415,18 @@
     <string name="gesture_handler_open_assistant">A segéd indítása</string>
     <string name="pick_app_for_gesture">Egy alkalmazás választása</string>
     <string name="dt2s_admin_hint_title">Adminisztrátori jogosultság szükséges</string>
-    <string name="dt2s_admin_hint">A \'Képernyőkikapcsolás Duplakoppal\' funkcióhoz állítsa be készülékvezérlőként a Lawnchair-t. Nyissa meg a Beállításokat és érintse meg az \"Aktiválja a készülék-adminisztrátori alkalmazást\" lehetőséget</string>
+    <string name="dt2s_admin_hint">A \'Képernyőkikapcsolás Duplakoppal\' funkcióhoz állítsa be készülékvezérlőként a AI asszisztens-t. Nyissa meg a Beállításokat és érintse meg az \"Aktiválja a készülék-adminisztrátori alkalmazást\" lehetőséget</string>
     <string name="dt2s_admin_warning">A \'Képernyőkikapcsolás Duplakoppal\' kikapcsolásra kerül.</string>
     <string name="d2ts_recents_a11y_hint_title">A \'Kisegítő lehetőségek\' bekapcsolása</string>
-    <string name="dt2s_a11y_hint">A \'Képernyőkikapcsolás Duplakoppal\' használatához kapcsolja be a Lawnchair \'Kisegítő lehetőségei\'-t. Koppintson a „Beállítások megnyitása”, válassza a „Lawnchair” lehetőséget, és kapcsolja be a „Lawnchair használata” lehetőséget.\n\nA Lawnchair az akadálymentesítés „performGlobalAction” metódusát használja a művelet végrehajtásához. Ez egy bizalmas engedély, amely lehetővé teszi más alkalmazások figyelését. A Lawnchair azonban nincs konfigurálva ehhez a funkcióhoz, és nem fogad eseményeket.</string>
+    <string name="dt2s_a11y_hint">A \'Képernyőkikapcsolás Duplakoppal\' használatához kapcsolja be a AI asszisztens \'Kisegítő lehetőségei\'-t. Koppintson a „Beállítások megnyitása”, válassza a „AI asszisztens” lehetőséget, és kapcsolja be a „AI asszisztens használata” lehetőséget.\n\nA AI asszisztens az akadálymentesítés „performGlobalAction” metódusát használja a művelet végrehajtásához. Ez egy bizalmas engedély, amely lehetővé teszi más alkalmazások figyelését. A AI asszisztens azonban nincs konfigurálva ehhez a funkcióhoz, és nem fogad eseményeket.</string>
     <string name="dt2s_recents_warning_open_settings">A Beállítások megnyitása</string>
-    <string name="recents_a11y_hint">To use Open Recents screen, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="recents_a11y_hint">To use Open Recents screen, turn on the AI asszisztens accessibility service. Tap \"Open settings\", select \"AI asszisztens\" and turn on \"Use AI asszisztens.\"\n\nAI asszisztens uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, AI asszisztens is not configured for that functionality and receives no events.</string>
     <!--
 
     Bug reporting
 
     -->
-    <string name="lawnchair_bug_report">Lawnchair-hibajelentés</string>
+    <string name="lawnchair_bug_report">AI asszisztens-hibajelentés</string>
     <string name="crash_report_notif_title">A(z) %1$s összeomlott</string>
     <string name="action_upload_crash_report">Összeomlási napló feltöltése</string>
     <string name="action_upload_error">Feltöltési hiba</string>
@@ -519,7 +519,7 @@
     <!-- Search providers -->
     <string name="search_provider_app_search">Alkalmazáskereső</string>
     <string name="search_provider_custom">Egyéni</string>
-    <string name="search_provider_sponsored_description">%1$s és a Lawnchair bevételmegosztási megállapodást kötött.\n\nHa %1$s végzi a keresést, azzal segít a Lawnchair-nek is.</string>
+    <string name="search_provider_sponsored_description">%1$s és a AI asszisztens bevételmegosztási megállapodást kötött.\n\nHa %1$s végzi a keresést, azzal segít a AI asszisztens-nek is.</string>
     <string name="app_label">Alkalmazás</string>
     <string name="website_label">Weboldal</string>
     <string name="qsb_search_provider_app_required">Ehhez kell egy alkalmazás</string>
@@ -552,7 +552,7 @@
     <string name="max_folder_columns">A mappaoszlopok maximuma</string>
     <string name="max_folder_rows">A mappasorok maximuma</string>
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">These settings will be ignored as Lawnchair isn\'t set as the Recents screen provider</string>
+    <string name="quickswitch_ignored_warning">These settings will be ignored as AI asszisztens isn\'t set as the Recents screen provider</string>
     <string name="quickstep_incompatible">Nem kompatibilis rendszer-integráció</string>
     <string name="quickstep_incompatible_description">Készüléke úgy van konfigurálva, hogy a(z) %1$s által biztosított rendszermozdulatokat (az úgynevezett Quickstep-et) tartalmazza, de a %1$s-verzió nem kompatibilis az Android-verzióval. A készülék további használatához, kérjük távolítsa el az utolsó %1$s-frissítést vagy állítsa be úgy készülékét hogy nem a(z) %1$s a rendszer mozdulatvezérlője.</string>
     <string name="translucent_background">Átlátszó háttér</string>

--- a/lawnchair/res/values-hu/strings.xml
+++ b/lawnchair/res/values-hu/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI asszisztens
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-hy/strings.xml
+++ b/lawnchair/res/values-hy/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI օգնական
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-id/strings.xml
+++ b/lawnchair/res/values-id/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, Asisten ai
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -71,10 +71,10 @@
         <item quantity="other">%1$d Aplikasi</item>
     </plurals>
     <string name="dt2s_admin_hint_title">Izin Admin Dibutuhkan</string>
-    <string name="dt2s_admin_hint">Untuk menggunakan Ketuk Dua Kali untuk Tidur, atur Lawnchair sebagai aplikasi admin perangkat. Ketuk \"Buka Pengaturan,\" lalu ketuk \"Aktifkan aplikasi admin perangkat ini.\"</string>
+    <string name="dt2s_admin_hint">Untuk menggunakan Ketuk Dua Kali untuk Tidur, atur Asisten ai sebagai aplikasi admin perangkat. Ketuk \"Buka Pengaturan,\" lalu ketuk \"Aktifkan aplikasi admin perangkat ini.\"</string>
     <string name="dt2s_admin_warning">Ketuk Dua Kali untuk Tidur akan dimatikan.</string>
     <string name="dt2s_a11y_hint_title">Aktifkan Layanan Aksesibilitas</string>
-    <string name="dt2s_a11y_hint">Untuk menggunakan Ketuk Dua Kali untuk Tidur, aktifkan layanan aksesibilitas Lawnchair. Ketuk \"Buka Pengaturan,\" lalu pilih \"Lawnchair\" dan aktifkan \"Gunakan Lawnchair\".</string>
+    <string name="dt2s_a11y_hint">Untuk menggunakan Ketuk Dua Kali untuk Tidur, aktifkan layanan aksesibilitas Asisten ai. Ketuk \"Buka Pengaturan,\" lalu pilih \"Asisten ai\" dan aktifkan \"Gunakan Asisten ai\".</string>
     <string name="dt2s_warning_open_settings">Buka Pengaturan</string>
     <string name="minus_one_enable">Umpan</string>
     <string name="minus_one_unavailable">Tidak ada umpan terpasang.</string>
@@ -104,7 +104,7 @@
     <string name="missing_notification_access_description">Akses notifikasi diperlukan.</string>
     <string name="msg_missing_notification_access">Untuk menggunakan Titik Notifikasi, berikan <xliff:g id="name" example="Aplikasi Saya">%1$s</xliff:g> akses ke notifikasi.</string>
     <string name="title_change_settings">Ubah Pengaturan</string>
-    <string name="debug_restart_launcher">Muat ulang Lawnchair</string>
+    <string name="debug_restart_launcher">Muat ulang Asisten ai</string>
     <string name="pref_fonts_missing_font">Font tidak ditemukan.</string>
     <string name="font_variant_italic">Miring</string>
     <string name="font_weight_thin">Tipis</string>
@@ -143,7 +143,7 @@
     <string name="dynamic">Dinamis</string>
     <string name="all_apps_search_market_message">Cari Aplikasi Lainnya</string>
     <string name="show_app_search_bar">Tampilkan Bilah Pencarian</string>
-    <string name="lawnchair_bug_report">Laporan Bug Lawnchair</string>
+    <string name="lawnchair_bug_report">Laporan Bug Asisten ai</string>
     <string name="crash_report_notif_title">%1$s berhenti</string>
     <string name="action_copy_link">Salin Tautan</string>
     <string name="action_copy">Salin</string>

--- a/lawnchair/res/values-in-rID/strings.xml
+++ b/lawnchair/res/values-in-rID/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, Asisten ai
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@
     <string name="time_weeks_ago">%dw</string>
     <string name="time_months_ago">%dmo</string>
     <string name="time_years_ago">%dy</string>
-    <string name="managed_by_lawnchair">Dikelola oleh Lawnchair</string>
+    <string name="managed_by_lawnchair">Dikelola oleh Asisten ai</string>
     <!-- When mentioning settings UI -->
     <string name="smartspace_preferences">Preferensi</string>
     <string name="settings_button_text">Pengaturan beranda</string>
@@ -69,7 +69,7 @@
     <string name="title_change_settings">Ubah pengaturan</string>
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout Asisten ai
 
     -->
     <string name="others_category_label">Lainnya</string>
@@ -114,7 +114,7 @@
     <string name="folders_filter_duplicates">Tunjukkan aplikasi yang unik saja</string>
     <string name="my_folder_label">Folder saya</string>
     <!-- A11y description -->
-    <string name="accessibility_service_description">Agar dapat melakukan suatu aksi (misalnya mengunci ponsel) saat melakukan gesture, Lawnchair butuh izin aksesibilitas.\n\nLawnchair tidak melihat aksi pengguna apa pun, meskipun kemampuan tersebut dibutuhkan untuk semua layanan aksesibilitas. Lawnchair mengabaikan event yang dikirim oleh sistem.\n\nAgar dapat mengunci ponsel Anda, atau membuka layar terbaru, Lawnchair memakai API aksesibilitas \"performGlobalAction\".</string>
+    <string name="accessibility_service_description">Agar dapat melakukan suatu aksi (misalnya mengunci ponsel) saat melakukan gesture, Asisten ai butuh izin aksesibilitas.\n\nAsisten ai tidak melihat aksi pengguna apa pun, meskipun kemampuan tersebut dibutuhkan untuk semua layanan aksesibilitas. Asisten ai mengabaikan event yang dikirim oleh sistem.\n\nAgar dapat mengunci ponsel Anda, atau membuka layar terbaru, Asisten ai memakai API aksesibilitas \"performGlobalAction\".</string>
     <string name="x_with_y_count">%1$s (%2$d)</string>
     <string name="x_by_y">%1$d × %2$d</string>
     <string name="x_and_y">%1$s &amp; %2$s</string>
@@ -143,7 +143,7 @@
     <string name="quickstep_description">Tombol Hapus Semua, radius sudut</string>
     <string name="about_label">Tentang</string>
     <string name="app_info_drop_target_label">Info aplikasi</string>
-    <string name="debug_restart_launcher">Muat ulang Lawnchair</string>
+    <string name="debug_restart_launcher">Muat ulang Asisten ai</string>
     <string name="experimental_features_label">Masa datang eksperimental</string>
     <!-- Experimental features -->
     <string name="font_picker_label">Perubahan huruf</string>
@@ -171,7 +171,7 @@
     Notifications
 
     -->
-    <string name="set_default_launcher_tip">Untuk mengakses pintasan dan kelebihan tambahan, atur Lawnchair sebagai peluncur bawaan Anda</string>
+    <string name="set_default_launcher_tip">Untuk mengakses pintasan dan kelebihan tambahan, atur Asisten ai sebagai peluncur bawaan Anda</string>
     <string name="notification_dots">Titik notifikasi</string>
     <string name="show_notification_count">Tampilkan jumlah notifikasi</string>
     <string name="notification_dots_color">Warna titik notifikasi</string>
@@ -344,7 +344,7 @@
     <string name="event_provider_missing_notification_dots">Untuk gunakan <xliff:g example="My Provider" id="providerName">%1$s</xliff:g>, nyalakan Titik Notifikasi.</string>
     <!-- Toggle button for enabling Smartspace -->
     <string name="smartspace_widget_toggle_label">Tampilkan di layar beranda</string>
-    <string name="smartspace_widget_toggle_description">Sekilas dapat ditambahkan secara manual ke layar beranda dengan menaruh widget Lawnchair</string>
+    <string name="smartspace_widget_toggle_description">Sekilas dapat ditambahkan secara manual ke layar beranda dengan menaruh widget Asisten ai</string>
     <!-- List of available providers -->
     <string name="smartspace_mode_label">Penyedia Sekilas</string>
     <string name="smartspace_mode_google">Google</string>
@@ -415,18 +415,18 @@
     <string name="gesture_handler_open_assistant">Buka asisten</string>
     <string name="pick_app_for_gesture">Pilih apli</string>
     <string name="dt2s_admin_hint_title">Izin admin diperlukan</string>
-    <string name="dt2s_admin_hint">Untuk menggunakan Ketuk Dua Kali untuk Tidur, atur Lawnchair sebagai apli admin perangkat. Ketuk \"Buka pengaturan\", lalu ketuk \"Aktifkan apli admin perangkat ini.\"</string>
+    <string name="dt2s_admin_hint">Untuk menggunakan Ketuk Dua Kali untuk Tidur, atur Asisten ai sebagai apli admin perangkat. Ketuk \"Buka pengaturan\", lalu ketuk \"Aktifkan apli admin perangkat ini.\"</string>
     <string name="dt2s_admin_warning">Tap Dua Kali untuk Tidur akan dimatikan.</string>
     <string name="d2ts_recents_a11y_hint_title">Aktifkan layanan aksesibilitas</string>
-    <string name="dt2s_a11y_hint">Untuk menggunakan Ketuk-Ganda untuk Tidur, aktifkan layanan aksesibilitas Lawnchair. Ketuk \"Buka pengaturan\", pilih \"Lawnchair\" dan aktifkan \"Gunakan Lawnchair\".\n\nLawnchair menggunakan metode performGlobalAction dari Aksesibilitas untuk melakukan tindakan ini. Ini adalah izin sensitif yang memungkinkan pemantauan aplikasi lain. Namun, Lawnchair tidak dikonfigurasi untuk fungsi tersebut dan tidak menerima acara apa pun.</string>
+    <string name="dt2s_a11y_hint">Untuk menggunakan Ketuk-Ganda untuk Tidur, aktifkan layanan aksesibilitas Asisten ai. Ketuk \"Buka pengaturan\", pilih \"Asisten ai\" dan aktifkan \"Gunakan Asisten ai\".\n\nAsisten ai menggunakan metode performGlobalAction dari Aksesibilitas untuk melakukan tindakan ini. Ini adalah izin sensitif yang memungkinkan pemantauan aplikasi lain. Namun, Asisten ai tidak dikonfigurasi untuk fungsi tersebut dan tidak menerima acara apa pun.</string>
     <string name="dt2s_recents_warning_open_settings">Buka pengaturan</string>
-    <string name="recents_a11y_hint">Untuk menggunakan Buka layar terbaru, aktifkan layanan aksesibilitas Lawnchair. Ketuk \"Buka pengaturan\", pilih \"Lawnchair\" dan aktifkan \"Gunakan Lawnchair\".\n\nLawnchair menggunakan metode `performGlobalAction` dari Aksesibilitas untuk melakukan tindakan ini. Ini adalah izin sensitif yang memungkinkan pemantauan aplikasi lain. Namun, Lawnchair tidak dikonfigurasi untuk fungsi tersebut dan tidak menerima kejadian apa pun.</string>
+    <string name="recents_a11y_hint">Untuk menggunakan Buka layar terbaru, aktifkan layanan aksesibilitas Asisten ai. Ketuk \"Buka pengaturan\", pilih \"Asisten ai\" dan aktifkan \"Gunakan Asisten ai\".\n\nAsisten ai menggunakan metode `performGlobalAction` dari Aksesibilitas untuk melakukan tindakan ini. Ini adalah izin sensitif yang memungkinkan pemantauan aplikasi lain. Namun, Asisten ai tidak dikonfigurasi untuk fungsi tersebut dan tidak menerima kejadian apa pun.</string>
     <!--
 
     Bug reporting
 
     -->
-    <string name="lawnchair_bug_report">Laporan bug Lawnchair</string>
+    <string name="lawnchair_bug_report">Laporan bug Asisten ai</string>
     <string name="crash_report_notif_title">%1$s mogok</string>
     <string name="action_upload_crash_report">Unggah laporan mogok</string>
     <string name="action_upload_error">Gagal mengunggah</string>
@@ -519,7 +519,7 @@
     <!-- Search providers -->
     <string name="search_provider_app_search">Pencarian apli</string>
     <string name="search_provider_custom">Kustom</string>
-    <string name="search_provider_sponsored_description">%1$s dan Lawnchair memiliki persetujuan pembagian hasil.\n\nMencari dengan %1$s membantu mendukung Lawnchair.</string>
+    <string name="search_provider_sponsored_description">%1$s dan Asisten ai memiliki persetujuan pembagian hasil.\n\nMencari dengan %1$s membantu mendukung Asisten ai.</string>
     <string name="app_label">Aplikasi</string>
     <string name="website_label">Website</string>
     <string name="qsb_search_provider_app_required">Aplikasi diperlukan</string>
@@ -551,7 +551,7 @@
     <string name="max_folder_columns">Kolom folder maksimum</string>
     <string name="max_folder_rows">Baris folder maksimum</string>
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">Pengaturan ini akan diabaikan karena Lawnchair tidak diatur sebagai penyedia layar terbaru</string>
+    <string name="quickswitch_ignored_warning">Pengaturan ini akan diabaikan karena Asisten ai tidak diatur sebagai penyedia layar terbaru</string>
     <string name="quickstep_incompatible">Integrasi sistem tidak kompatibel</string>
     <string name="quickstep_incompatible_description">Perangkat Anda dikonfigurasi untuk menggunakan gestur sistem (dikenal sebagai Quickstep) disediakan oleh %1$s, tetapi versi %1$s tidak kompatibel dengan versi Android Anda. Untuk melanjutkan menggunakan perangkat Anda, harap lepas pembarian %1$s atau nonaktifkan %1$s sebagai penyedia gestur sistem.</string>
     <string name="translucent_background">Latar belakang transparan</string>

--- a/lawnchair/res/values-in/strings.xml
+++ b/lawnchair/res/values-in/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, Asisten ai
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-is/strings.xml
+++ b/lawnchair/res/values-is/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI aðstoðarmaður
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-it-rIT/strings.xml
+++ b/lawnchair/res/values-it-rIT/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, Assistente ai
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@
     <string name="time_weeks_ago">%dw</string>
     <string name="time_months_ago">%dmo</string>
     <string name="time_years_ago">%dy</string>
-    <string name="managed_by_lawnchair">Gestito da Lawnchair</string>
+    <string name="managed_by_lawnchair">Gestito da Assistente ai</string>
     <!-- When mentioning settings UI -->
     <string name="smartspace_preferences">Preferenze</string>
     <string name="settings_button_text">Impostazioni Schermata Home</string>
@@ -69,7 +69,7 @@
     <string name="title_change_settings">Modifica impostazioni</string>
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout Assistente ai
 
     -->
     <string name="others_category_label"></string>
@@ -114,7 +114,7 @@
     <string name="folders_filter_duplicates">Mostra solo app uniche</string>
     <string name="my_folder_label">La mia cartella</string>
     <!-- A11y description -->
-    <string name="accessibility_service_description">Per eseguire determinate azioni (come bloccare il telefono) quando si esegue un gesto, Lawnchair richiede l\'accesso all\'accessibilità.\n\nLawnchair non guarda nessuna azione utente, sebbene il privilegio di farlo sia richiesto per tutti i servizi di accessibilità. Lawnchair scarta qualsiasi evento inviato dal sistema.\n\nPer bloccare il telefono, o per aprire la Schermata dei recenti, Lawnchair utilizza il servizio di accessibilità performGlobalAction.</string>
+    <string name="accessibility_service_description">Per eseguire determinate azioni (come bloccare il telefono) quando si esegue un gesto, Assistente ai richiede l\'accesso all\'accessibilità.\n\nAssistente ai non guarda nessuna azione utente, sebbene il privilegio di farlo sia richiesto per tutti i servizi di accessibilità. Assistente ai scarta qualsiasi evento inviato dal sistema.\n\nPer bloccare il telefono, o per aprire la Schermata dei recenti, Assistente ai utilizza il servizio di accessibilità performGlobalAction.</string>
     <string name="x_with_y_count">%1$s (%2$d)</string>
     <string name="x_by_y">%1$d × %2$d</string>
     <string name="x_and_y">%1$s e %2$s</string>
@@ -143,7 +143,7 @@
     <string name="quickstep_description">Pulsante Cancella Tutto, raggio dell\'angolo</string>
     <string name="about_label">Informazioni</string>
     <string name="app_info_drop_target_label">Informazioni sull\'app</string>
-    <string name="debug_restart_launcher">Riavvia Lawnchair</string>
+    <string name="debug_restart_launcher">Riavvia Assistente ai</string>
     <string name="experimental_features_label">Funzionalità sperimentali</string>
     <!-- Experimental features -->
     <string name="font_picker_label">Personalizzazione del font</string>
@@ -171,7 +171,7 @@
     Notifications
 
     -->
-    <string name="set_default_launcher_tip">Per accedere alle scorciatoie e ad altre funzioni aggiuntive, imposta Lawnchair come launcher predefinito</string>
+    <string name="set_default_launcher_tip">Per accedere alle scorciatoie e ad altre funzioni aggiuntive, imposta Assistente ai come launcher predefinito</string>
     <string name="notification_dots">Punti di notifica</string>
     <string name="show_notification_count">Mostra Contatore di notifica</string>
     <string name="notification_dots_color">Colore dei Punti di notifica</string>
@@ -344,7 +344,7 @@
     <string name="event_provider_missing_notification_dots">Per utilizzare <xliff:g example="My Provider" id="providerName">%1$s</xliff:g>, attiva i Punti di notifica.</string>
     <!-- Toggle button for enabling Smartspace -->
     <string name="smartspace_widget_toggle_label">Mostra nella schermata home</string>
-    <string name="smartspace_widget_toggle_description">‘A Colpo d\'Occhio’ può essere aggiunto manualmente alla schermata home inserendo il widget di Lawnchair</string>
+    <string name="smartspace_widget_toggle_description">‘A Colpo d\'Occhio’ può essere aggiunto manualmente alla schermata home inserendo il widget di Assistente ai</string>
     <!-- List of available providers -->
     <string name="smartspace_mode_label">Fornitore di ‘A Colpo d\'Occhio’</string>
     <string name="smartspace_mode_google">Google</string>
@@ -415,18 +415,18 @@
     <string name="gesture_handler_open_assistant">Apri assistente</string>
     <string name="pick_app_for_gesture">Seleziona l\'app</string>
     <string name="dt2s_admin_hint_title">Permessi di amministratore necessari</string>
-    <string name="dt2s_admin_hint">Per sospendere lo schermo con un doppio tocco, imposta Lawnchair come amministratore del dispositivo. Tocca \"Apri impostazioni\", poi tocca \"Attiva questa app come amministratore del dispositivo\".</string>
+    <string name="dt2s_admin_hint">Per sospendere lo schermo con un doppio tocco, imposta Assistente ai come amministratore del dispositivo. Tocca \"Apri impostazioni\", poi tocca \"Attiva questa app come amministratore del dispositivo\".</string>
     <string name="dt2s_admin_warning">La sospensione con un doppio tocco sarà disabilitata.</string>
     <string name="d2ts_recents_a11y_hint_title">Abilita il servizio di accessibilità</string>
-    <string name="dt2s_a11y_hint">Per sospendere lo schermo con un doppio tocco, abilita il servizio di accessibilità di Lawnchair. Tocca \"Apri impostazioni\", seleziona \"Lawnchair\" e abilita \"Usa Lawnchair\".\n\nLawnchair utilizza il metodo di accessibilità `performGlobalAction` per effettuare questa operazione. Si tratta di un permesso sensibile che permette di monitorare altre app, tuttavia Lawnchair non è configurato per quella funzionalità e non riceve alcun evento.</string>
+    <string name="dt2s_a11y_hint">Per sospendere lo schermo con un doppio tocco, abilita il servizio di accessibilità di Assistente ai. Tocca \"Apri impostazioni\", seleziona \"Assistente ai\" e abilita \"Usa Assistente ai\".\n\nAssistente ai utilizza il metodo di accessibilità `performGlobalAction` per effettuare questa operazione. Si tratta di un permesso sensibile che permette di monitorare altre app, tuttavia Assistente ai non è configurato per quella funzionalità e non riceve alcun evento.</string>
     <string name="dt2s_recents_warning_open_settings">Apri impostazioni</string>
-    <string name="recents_a11y_hint">Per utilizzare Apri schermata recenti, abilita il servizio di accessibilità di Lawnchair. Tocca \"Apri impostazioni\", seleziona \"Lawnchair\" e abilita \"Usa Lawnchair\".\n\nLawnchair utilizza il metodo di accessibilità `performGlobalAction` per effettuare questa operazione. Si tratta di un permesso sensibile che permette di monitorare altre app, tuttavia Lawnchair non è configurato per quella funzionalità e non riceve alcun evento.</string>
+    <string name="recents_a11y_hint">Per utilizzare Apri schermata recenti, abilita il servizio di accessibilità di Assistente ai. Tocca \"Apri impostazioni\", seleziona \"Assistente ai\" e abilita \"Usa Assistente ai\".\n\nAssistente ai utilizza il metodo di accessibilità `performGlobalAction` per effettuare questa operazione. Si tratta di un permesso sensibile che permette di monitorare altre app, tuttavia Assistente ai non è configurato per quella funzionalità e non riceve alcun evento.</string>
     <!--
 
     Bug reporting
 
     -->
-    <string name="lawnchair_bug_report">Segnalazione di un bug con Lawnchair</string>
+    <string name="lawnchair_bug_report">Segnalazione di un bug con Assistente ai</string>
     <string name="crash_report_notif_title">%1$s è crashata</string>
     <string name="action_upload_crash_report">Carica log del crash</string>
     <string name="action_upload_error">Caricamento fallito</string>
@@ -519,7 +519,7 @@
     <!-- Search providers -->
     <string name="search_provider_app_search">Ricerca delle app</string>
     <string name="search_provider_custom">Personalizzato</string>
-    <string name="search_provider_sponsored_description">%1$s e Lawnchair hanno un accordo di condivisione delle entrate.\n\nLa ricerca tramite %1$s aiuta a supportare Lawnchair.</string>
+    <string name="search_provider_sponsored_description">%1$s e Assistente ai hanno un accordo di condivisione delle entrate.\n\nLa ricerca tramite %1$s aiuta a supportare Assistente ai.</string>
     <string name="app_label">App</string>
     <string name="website_label">Sito web</string>
     <string name="qsb_search_provider_app_required">App necessaria</string>
@@ -552,7 +552,7 @@
     <string name="max_folder_columns">Numero massimo di colonne nelle cartelle</string>
     <string name="max_folder_rows">Numero massimo di righe nelle cartelle</string>
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">Queste impostazioni saranno ignorate perché Lawnchair non è impostato come fornitore della Schermata recenti</string>
+    <string name="quickswitch_ignored_warning">Queste impostazioni saranno ignorate perché Assistente ai non è impostato come fornitore della Schermata recenti</string>
     <string name="quickstep_incompatible">Integrazione di sistema incompatibile</string>
     <string name="quickstep_incompatible_description">Il tuo dispositivo è configurato per avere i gesti di sistema (noti come Quickstep) forniti da %1$s, ma questa versione di %1$s non è compatibile con la tua versione di Android. Per continuare ad usare il tuo dispositivo, disinstalla gli aggiornamenti di %1$s o disabilita %1$s come fornitore dei gesti di sistema.</string>
     <string name="translucent_background">Sfondo traslucido</string>

--- a/lawnchair/res/values-it/strings.xml
+++ b/lawnchair/res/values-it/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, Assistente ai
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-iw-rIL/strings.xml
+++ b/lawnchair/res/values-iw-rIL/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, עוזר AI
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@
     <string name="time_weeks_ago">%dw</string>
     <string name="time_months_ago">%dmo</string>
     <string name="time_years_ago">%dy</string>
-    <string name="managed_by_lawnchair">מנוהל ע\"י Lawnchair</string>
+    <string name="managed_by_lawnchair">מנוהל ע\"י עוזר AI</string>
     <!-- When mentioning settings UI -->
     <string name="smartspace_preferences">העדפות</string>
     <string name="settings_button_text">הגדרות כפתור בית</string>
@@ -69,7 +69,7 @@
     <string name="title_change_settings">Change settings</string>
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout עוזר AI
 
     -->
     <string name="others_category_label">Others</string>
@@ -114,7 +114,7 @@
     <string name="folders_filter_duplicates">Only show unique apps</string>
     <string name="my_folder_label">My folder</string>
     <!-- A11y description -->
-    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, Lawnchair uses the performGlobalAction Accessibility service.</string>
+    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, עוזר AI requires accessibility access.\n\nעוזר AI doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. עוזר AI discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, עוזר AI uses the performGlobalAction Accessibility service.</string>
     <string name="x_with_y_count">%1$s (%2$d)</string>
     <string name="x_by_y">%1$d x %2$d</string>
     <string name="x_and_y">%1$s &amp; %2$s</string>
@@ -143,7 +143,7 @@
     <string name="quickstep_description">Clear All button, corner radius</string>
     <string name="about_label">על אודות</string>
     <string name="app_info_drop_target_label">App info</string>
-    <string name="debug_restart_launcher">איתחול Lawnchair</string>
+    <string name="debug_restart_launcher">איתחול עוזר AI</string>
     <string name="experimental_features_label">Experimental features</string>
     <!-- Experimental features -->
     <string name="font_picker_label">Font customization</string>
@@ -171,7 +171,7 @@
     Notifications
 
     -->
-    <string name="set_default_launcher_tip">To access shortcuts and additional features, set Lawnchair as your default launcher</string>
+    <string name="set_default_launcher_tip">To access shortcuts and additional features, set עוזר AI as your default launcher</string>
     <string name="notification_dots">Notification dots</string>
     <string name="show_notification_count">Show notification counter</string>
     <string name="notification_dots_color">Notification dot color</string>
@@ -344,7 +344,7 @@
     <string name="event_provider_missing_notification_dots">To use <xliff:g example="My Provider" id="providerName">%1$s</xliff:g>, turn on Notification Dots.</string>
     <!-- Toggle button for enabling Smartspace -->
     <string name="smartspace_widget_toggle_label">Show on home screen</string>
-    <string name="smartspace_widget_toggle_description">At a Glance can be manually added to the home screen by placing the Lawnchair widget</string>
+    <string name="smartspace_widget_toggle_description">At a Glance can be manually added to the home screen by placing the עוזר AI widget</string>
     <!-- List of available providers -->
     <string name="smartspace_mode_label">At a Glance provider</string>
     <string name="smartspace_mode_google">גוגל</string>
@@ -415,18 +415,18 @@
     <string name="gesture_handler_open_assistant">Open assistant</string>
     <string name="pick_app_for_gesture">Pick app</string>
     <string name="dt2s_admin_hint_title">Admin permissions required</string>
-    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set Lawnchair as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
+    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set עוזר AI as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
     <string name="dt2s_admin_warning">Double Tap to Sleep will be disabled.</string>
     <string name="d2ts_recents_a11y_hint_title">Turn on accessibility service</string>
-    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the עוזר AI accessibility service. Tap \"Open settings\", select \"עוזר AI\" and turn on \"Use עוזר AI.\"\n\nעוזר AI uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, עוזר AI is not configured for that functionality and receives no events.</string>
     <string name="dt2s_recents_warning_open_settings">Open settings</string>
-    <string name="recents_a11y_hint">To use Open Recents screen, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="recents_a11y_hint">To use Open Recents screen, turn on the עוזר AI accessibility service. Tap \"Open settings\", select \"עוזר AI\" and turn on \"Use עוזר AI.\"\n\nעוזר AI uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, עוזר AI is not configured for that functionality and receives no events.</string>
     <!--
 
     Bug reporting
 
     -->
-    <string name="lawnchair_bug_report">Lawnchair bug report</string>
+    <string name="lawnchair_bug_report">עוזר AI bug report</string>
     <string name="crash_report_notif_title">%1$s crashed</string>
     <string name="action_upload_crash_report">Upload crash log</string>
     <string name="action_upload_error">העלאה נכשלה</string>
@@ -519,7 +519,7 @@
     <!-- Search providers -->
     <string name="search_provider_app_search">App search</string>
     <string name="search_provider_custom">התאמה אישית</string>
-    <string name="search_provider_sponsored_description">%1$s and Lawnchair have a revenue share agreement.\n\nSearching with %1$s helps support Lawnchair.</string>
+    <string name="search_provider_sponsored_description">%1$s and עוזר AI have a revenue share agreement.\n\nSearching with %1$s helps support עוזר AI.</string>
     <string name="app_label">יישום</string>
     <string name="website_label">אתר</string>
     <string name="qsb_search_provider_app_required">App required</string>
@@ -554,7 +554,7 @@
     <string name="max_folder_columns">Maximum folder columns</string>
     <string name="max_folder_rows">Maximum folder rows</string>
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">These settings will be ignored as Lawnchair isn\'t set as the Recents screen provider</string>
+    <string name="quickswitch_ignored_warning">These settings will be ignored as עוזר AI isn\'t set as the Recents screen provider</string>
     <string name="quickstep_incompatible">Incompatible system integration</string>
     <string name="quickstep_incompatible_description">Your device is configured to have system gestures (known as Quickstep) provided by %1$s, but this version of %1$s isn\'t compatible with your Android version. To continue using your device, please uninstall %1$s updates or disable %1$s as a system gesture provider.</string>
     <string name="translucent_background">Translucent background</string>

--- a/lawnchair/res/values-iw/strings.xml
+++ b/lawnchair/res/values-iw/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, עוזר AI
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-ja-rJP/strings.xml
+++ b/lawnchair/res/values-ja-rJP/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AIアシスタント
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@
     <string name="time_weeks_ago">%dw</string>
     <string name="time_months_ago">%dmo</string>
     <string name="time_years_ago">%dy</string>
-    <string name="managed_by_lawnchair">Lawnchair に管理されています</string>
+    <string name="managed_by_lawnchair">AIアシスタント に管理されています</string>
     <!-- When mentioning settings UI -->
     <string name="smartspace_preferences">設定</string>
     <string name="settings_button_text">ホーム設定</string>
@@ -69,7 +69,7 @@
     <string name="title_change_settings">設定を変更</string>
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout AIアシスタント
 
     -->
     <string name="others_category_label">その他</string>
@@ -114,7 +114,7 @@
     <string name="folders_filter_duplicates">固有のアプリのみ表示</string>
     <string name="my_folder_label">自分のフォルダ</string>
     <!-- A11y description -->
-    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, Lawnchair uses the performGlobalAction Accessibility service.</string>
+    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, AIアシスタント requires accessibility access.\n\nAIアシスタント doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. AIアシスタント discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, AIアシスタント uses the performGlobalAction Accessibility service.</string>
     <string name="x_with_y_count">%1$s (%2$d)</string>
     <string name="x_by_y">%1$d × %2$d</string>
     <string name="x_and_y">%1$s &amp; %2$s</string>
@@ -143,7 +143,7 @@
     <string name="quickstep_description">「すべてクリア」ボタン、角の丸み</string>
     <string name="about_label">このアプリについて</string>
     <string name="app_info_drop_target_label">アプリ情報</string>
-    <string name="debug_restart_launcher">Lawnchairを再起動</string>
+    <string name="debug_restart_launcher">AIアシスタントを再起動</string>
     <string name="experimental_features_label">実験的機能</string>
     <!-- Experimental features -->
     <string name="font_picker_label">フォントのカスタマイズ</string>
@@ -171,7 +171,7 @@
     Notifications
 
     -->
-    <string name="set_default_launcher_tip">ショートカットと追加機能にアクセスするには、Lawnchair をデフォルトのランチャーとして設定してください。</string>
+    <string name="set_default_launcher_tip">ショートカットと追加機能にアクセスするには、AIアシスタント をデフォルトのランチャーとして設定してください。</string>
     <string name="notification_dots">通知ドット</string>
     <string name="show_notification_count">通知の数を表示</string>
     <string name="notification_dots_color">通知ドットの色</string>
@@ -344,7 +344,7 @@
     <string name="event_provider_missing_notification_dots">To use <xliff:g example="My Provider" id="providerName">%1$s</xliff:g>, turn on Notification Dots.</string>
     <!-- Toggle button for enabling Smartspace -->
     <string name="smartspace_widget_toggle_label">ホーム画面に表示します</string>
-    <string name="smartspace_widget_toggle_description">スナップショットは、Lawnchairウィジェットを配置することでホーム画面に手動で追加できます</string>
+    <string name="smartspace_widget_toggle_description">スナップショットは、AIアシスタントウィジェットを配置することでホーム画面に手動で追加できます</string>
     <!-- List of available providers -->
     <string name="smartspace_mode_label">At a Glance のプロバイダー</string>
     <string name="smartspace_mode_google">Google</string>
@@ -415,18 +415,18 @@
     <string name="gesture_handler_open_assistant">Open assistant</string>
     <string name="pick_app_for_gesture">アプリを選択</string>
     <string name="dt2s_admin_hint_title">管理者権限が必要です</string>
-    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set Lawnchair as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
+    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set AIアシスタント as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
     <string name="dt2s_admin_warning">ダブルタップでスリープを解除します</string>
     <string name="d2ts_recents_a11y_hint_title">ユーザー補助サービスを ON にする</string>
-    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the AIアシスタント accessibility service. Tap \"Open settings\", select \"AIアシスタント\" and turn on \"Use AIアシスタント.\"\n\nAIアシスタント uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, AIアシスタント is not configured for that functionality and receives no events.</string>
     <string name="dt2s_recents_warning_open_settings">設定を開く</string>
-    <string name="recents_a11y_hint">To use Open Recents screen, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="recents_a11y_hint">To use Open Recents screen, turn on the AIアシスタント accessibility service. Tap \"Open settings\", select \"AIアシスタント\" and turn on \"Use AIアシスタント.\"\n\nAIアシスタント uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, AIアシスタント is not configured for that functionality and receives no events.</string>
     <!--
 
     Bug reporting
 
     -->
-    <string name="lawnchair_bug_report">Lawnchair のバグレポート</string>
+    <string name="lawnchair_bug_report">AIアシスタント のバグレポート</string>
     <string name="crash_report_notif_title">%1$s がクラッシュしました</string>
     <string name="action_upload_crash_report">クラッシュログをアップロード</string>
     <string name="action_upload_error">アップロードに失敗しました</string>
@@ -519,7 +519,7 @@
     <!-- Search providers -->
     <string name="search_provider_app_search">アプリ検索</string>
     <string name="search_provider_custom">カスタム</string>
-    <string name="search_provider_sponsored_description">%1$s and Lawnchair have a revenue share agreement.\n\nSearching with %1$s helps support Lawnchair.</string>
+    <string name="search_provider_sponsored_description">%1$s and AIアシスタント have a revenue share agreement.\n\nSearching with %1$s helps support AIアシスタント.</string>
     <string name="app_label">アプリ</string>
     <string name="website_label">ウェブサイト</string>
     <string name="qsb_search_provider_app_required">App required</string>
@@ -551,7 +551,7 @@
     <string name="max_folder_columns">最大のフォルダ列数</string>
     <string name="max_folder_rows">フォルダーの行の最大値</string>
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">These settings will be ignored as Lawnchair isn\'t set as the Recents screen provider</string>
+    <string name="quickswitch_ignored_warning">These settings will be ignored as AIアシスタント isn\'t set as the Recents screen provider</string>
     <string name="quickstep_incompatible">Incompatible system integration</string>
     <string name="quickstep_incompatible_description">Your device is configured to have system gestures (known as Quickstep) provided by %1$s, but this version of %1$s isn\'t compatible with your Android version. To continue using your device, please uninstall %1$s updates or disable %1$s as a system gesture provider.</string>
     <string name="translucent_background">半透明の背景</string>

--- a/lawnchair/res/values-ja/strings.xml
+++ b/lawnchair/res/values-ja/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AIアシスタント
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-ka-rGE/strings.xml
+++ b/lawnchair/res/values-ka-rGE/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI ასისტენტი
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@
     <string name="time_weeks_ago">%dw</string>
     <string name="time_months_ago">%dmo</string>
     <string name="time_years_ago">%dy</string>
-    <string name="managed_by_lawnchair">Lawnchair მართავს</string>
+    <string name="managed_by_lawnchair">AI ასისტენტი მართავს</string>
     <!-- When mentioning settings UI -->
     <string name="smartspace_preferences">პრეფერენციები</string>
     <string name="settings_button_text">მთავარის პარამეტრები</string>
@@ -69,7 +69,7 @@
     <string name="title_change_settings">პარამეტრების ცვლილება</string>
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout AI ასისტენტი
 
     -->
     <string name="others_category_label">Others</string>
@@ -114,7 +114,7 @@
     <string name="folders_filter_duplicates">Only show unique apps</string>
     <string name="my_folder_label">My folder</string>
     <!-- A11y description -->
-    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, Lawnchair uses the performGlobalAction Accessibility service.</string>
+    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, AI ასისტენტი requires accessibility access.\n\nAI ასისტენტი doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. AI ასისტენტი discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, AI ასისტენტი uses the performGlobalAction Accessibility service.</string>
     <string name="x_with_y_count">%1$s (%2$d)</string>
     <string name="x_by_y">%1$d x %2$d</string>
     <string name="x_and_y">%1$s &amp; %2$s</string>
@@ -143,7 +143,7 @@
     <string name="quickstep_description">Clear All button, corner radius</string>
     <string name="about_label">About</string>
     <string name="app_info_drop_target_label">App info</string>
-    <string name="debug_restart_launcher">Restart Lawnchair</string>
+    <string name="debug_restart_launcher">Restart AI ასისტენტი</string>
     <string name="experimental_features_label">Experimental features</string>
     <!-- Experimental features -->
     <string name="font_picker_label">Font customization</string>
@@ -171,7 +171,7 @@
     Notifications
 
     -->
-    <string name="set_default_launcher_tip">To access shortcuts and additional features, set Lawnchair as your default launcher</string>
+    <string name="set_default_launcher_tip">To access shortcuts and additional features, set AI ასისტენტი as your default launcher</string>
     <string name="notification_dots">Notification dots</string>
     <string name="show_notification_count">Show notification counter</string>
     <string name="notification_dots_color">Notification dot color</string>
@@ -344,7 +344,7 @@
     <string name="event_provider_missing_notification_dots">To use <xliff:g example="My Provider" id="providerName">%1$s</xliff:g>, turn on Notification Dots.</string>
     <!-- Toggle button for enabling Smartspace -->
     <string name="smartspace_widget_toggle_label">Show on home screen</string>
-    <string name="smartspace_widget_toggle_description">At a Glance can be manually added to the home screen by placing the Lawnchair widget</string>
+    <string name="smartspace_widget_toggle_description">At a Glance can be manually added to the home screen by placing the AI ასისტენტი widget</string>
     <!-- List of available providers -->
     <string name="smartspace_mode_label">At a Glance provider</string>
     <string name="smartspace_mode_google">Google</string>
@@ -415,18 +415,18 @@
     <string name="gesture_handler_open_assistant">Open assistant</string>
     <string name="pick_app_for_gesture">Pick app</string>
     <string name="dt2s_admin_hint_title">Admin permissions required</string>
-    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set Lawnchair as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
+    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set AI ასისტენტი as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
     <string name="dt2s_admin_warning">Double-Tap to Sleep will be turned off.</string>
     <string name="d2ts_recents_a11y_hint_title">Turn on accessibility service</string>
-    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the AI ასისტენტი accessibility service. Tap \"Open settings\", select \"AI ასისტენტი\" and turn on \"Use AI ასისტენტი.\"\n\nAI ასისტენტი uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, AI ასისტენტი is not configured for that functionality and receives no events.</string>
     <string name="dt2s_recents_warning_open_settings">Open settings</string>
-    <string name="recents_a11y_hint">To use Open Recents screen, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="recents_a11y_hint">To use Open Recents screen, turn on the AI ასისტენტი accessibility service. Tap \"Open settings\", select \"AI ასისტენტი\" and turn on \"Use AI ასისტენტი.\"\n\nAI ასისტენტი uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, AI ასისტენტი is not configured for that functionality and receives no events.</string>
     <!--
 
     Bug reporting
 
     -->
-    <string name="lawnchair_bug_report">Lawnchair bug report</string>
+    <string name="lawnchair_bug_report">AI ასისტენტი bug report</string>
     <string name="crash_report_notif_title">%1$s crashed</string>
     <string name="action_upload_crash_report">Upload crash log</string>
     <string name="action_upload_error">Upload failed</string>
@@ -519,7 +519,7 @@
     <!-- Search providers -->
     <string name="search_provider_app_search">App search</string>
     <string name="search_provider_custom">მორგებული</string>
-    <string name="search_provider_sponsored_description">%1$s and Lawnchair have a revenue share agreement.\n\nSearching with %1$s helps support Lawnchair.</string>
+    <string name="search_provider_sponsored_description">%1$s and AI ასისტენტი have a revenue share agreement.\n\nSearching with %1$s helps support AI ასისტენტი.</string>
     <string name="app_label">App</string>
     <string name="website_label">Website</string>
     <string name="qsb_search_provider_app_required">App required</string>
@@ -552,7 +552,7 @@
     <string name="max_folder_columns">Maximum folder columns</string>
     <string name="max_folder_rows">Maximum folder rows</string>
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">These settings will be ignored as Lawnchair isn\'t set as the Recents screen provider</string>
+    <string name="quickswitch_ignored_warning">These settings will be ignored as AI ასისტენტი isn\'t set as the Recents screen provider</string>
     <string name="quickstep_incompatible">Incompatible system integration</string>
     <string name="quickstep_incompatible_description">Your device is configured to have system gestures (known as Quickstep) provided by %1$s, but this version of %1$s isn\'t compatible with your Android version. To continue using your device, please uninstall %1$s updates or disable %1$s as a system gesture provider.</string>
     <string name="translucent_background">Translucent background</string>

--- a/lawnchair/res/values-ka/strings.xml
+++ b/lawnchair/res/values-ka/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI ასისტენტი
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-kk/strings.xml
+++ b/lawnchair/res/values-kk/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI көмекшісі
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-km/strings.xml
+++ b/lawnchair/res/values-km/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, ជំនួយការអេអាយ
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-kmr-rTR/strings.xml
+++ b/lawnchair/res/values-kmr-rTR/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, Alîkarê AI
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@
     <string name="time_weeks_ago">%dw</string>
     <string name="time_months_ago">%dmo</string>
     <string name="time_years_ago">%dy</string>
-    <string name="managed_by_lawnchair">Managed by Lawnchair</string>
+    <string name="managed_by_lawnchair">Managed by Alîkarê AI</string>
     <!-- When mentioning settings UI -->
     <string name="smartspace_preferences">Preferences</string>
     <string name="settings_button_text">Home settings</string>
@@ -69,7 +69,7 @@
     <string name="title_change_settings">Change settings</string>
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout Alîkarê AI
 
     -->
     <string name="others_category_label">Others</string>
@@ -114,7 +114,7 @@
     <string name="folders_filter_duplicates">Only show unique apps</string>
     <string name="my_folder_label">My folder</string>
     <!-- A11y description -->
-    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, Lawnchair uses the performGlobalAction Accessibility service.</string>
+    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, Alîkarê AI requires accessibility access.\n\nAlîkarê AI doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Alîkarê AI discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, Alîkarê AI uses the performGlobalAction Accessibility service.</string>
     <string name="x_with_y_count">%1$s (%2$d)</string>
     <string name="x_by_y">%1$d x %2$d</string>
     <string name="x_and_y">%1$s &amp; %2$s</string>
@@ -143,7 +143,7 @@
     <string name="quickstep_description">Clear All button, corner radius</string>
     <string name="about_label">Derbar</string>
     <string name="app_info_drop_target_label">App info</string>
-    <string name="debug_restart_launcher">Nûdestpêkirina Lawnchair</string>
+    <string name="debug_restart_launcher">Nûdestpêkirina Alîkarê AI</string>
     <string name="experimental_features_label">Experimental features</string>
     <!-- Experimental features -->
     <string name="font_picker_label">Font customization</string>
@@ -171,7 +171,7 @@
     Notifications
 
     -->
-    <string name="set_default_launcher_tip">To access shortcuts and additional features, set Lawnchair as your default launcher</string>
+    <string name="set_default_launcher_tip">To access shortcuts and additional features, set Alîkarê AI as your default launcher</string>
     <string name="notification_dots">Notification dots</string>
     <string name="show_notification_count">Show notification counter</string>
     <string name="notification_dots_color">Notification dot color</string>
@@ -344,7 +344,7 @@
     <string name="event_provider_missing_notification_dots">To use <xliff:g example="My Provider" id="providerName">%1$s</xliff:g>, turn on Notification Dots.</string>
     <!-- Toggle button for enabling Smartspace -->
     <string name="smartspace_widget_toggle_label">Show on home screen</string>
-    <string name="smartspace_widget_toggle_description">At a Glance can be manually added to the home screen by placing the Lawnchair widget</string>
+    <string name="smartspace_widget_toggle_description">At a Glance can be manually added to the home screen by placing the Alîkarê AI widget</string>
     <!-- List of available providers -->
     <string name="smartspace_mode_label">At a Glance provider</string>
     <string name="smartspace_mode_google">Google</string>
@@ -415,18 +415,18 @@
     <string name="gesture_handler_open_assistant">Open assistant</string>
     <string name="pick_app_for_gesture">Pick app</string>
     <string name="dt2s_admin_hint_title">Admin permissions required</string>
-    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set Lawnchair as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
+    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set Alîkarê AI as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
     <string name="dt2s_admin_warning">Double-Tap to Sleep will be turned off.</string>
     <string name="d2ts_recents_a11y_hint_title">Turn on accessibility service</string>
-    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the Alîkarê AI accessibility service. Tap \"Open settings\", select \"Alîkarê AI\" and turn on \"Use Alîkarê AI.\"\n\nAlîkarê AI uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Alîkarê AI is not configured for that functionality and receives no events.</string>
     <string name="dt2s_recents_warning_open_settings">Open settings</string>
-    <string name="recents_a11y_hint">To use Open Recents screen, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="recents_a11y_hint">To use Open Recents screen, turn on the Alîkarê AI accessibility service. Tap \"Open settings\", select \"Alîkarê AI\" and turn on \"Use Alîkarê AI.\"\n\nAlîkarê AI uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Alîkarê AI is not configured for that functionality and receives no events.</string>
     <!--
 
     Bug reporting
 
     -->
-    <string name="lawnchair_bug_report">Lawnchair bug report</string>
+    <string name="lawnchair_bug_report">Alîkarê AI bug report</string>
     <string name="crash_report_notif_title">%1$s crashed</string>
     <string name="action_upload_crash_report">Upload crash log</string>
     <string name="action_upload_error">Upload failed</string>
@@ -519,7 +519,7 @@
     <!-- Search providers -->
     <string name="search_provider_app_search">App search</string>
     <string name="search_provider_custom">Custom</string>
-    <string name="search_provider_sponsored_description">%1$s and Lawnchair have a revenue share agreement.\n\nSearching with %1$s helps support Lawnchair.</string>
+    <string name="search_provider_sponsored_description">%1$s and Alîkarê AI have a revenue share agreement.\n\nSearching with %1$s helps support Alîkarê AI.</string>
     <string name="app_label">App</string>
     <string name="website_label">Website</string>
     <string name="qsb_search_provider_app_required">App required</string>
@@ -552,7 +552,7 @@
     <string name="max_folder_columns">Maximum folder columns</string>
     <string name="max_folder_rows">Maximum folder rows</string>
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">These settings will be ignored as Lawnchair isn\'t set as the Recents screen provider</string>
+    <string name="quickswitch_ignored_warning">These settings will be ignored as Alîkarê AI isn\'t set as the Recents screen provider</string>
     <string name="quickstep_incompatible">Incompatible system integration</string>
     <string name="quickstep_incompatible_description">Your device is configured to have system gestures (known as Quickstep) provided by %1$s, but this version of %1$s isn\'t compatible with your Android version. To continue using your device, please uninstall %1$s updates or disable %1$s as a system gesture provider.</string>
     <string name="translucent_background">Translucent background</string>

--- a/lawnchair/res/values-kn/strings.xml
+++ b/lawnchair/res/values-kn/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI ಸಹಾಯಕ
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-ko-rKR/strings.xml
+++ b/lawnchair/res/values-ko-rKR/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI 보조
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@
     <string name="time_weeks_ago">%dw</string>
     <string name="time_months_ago">%dmo</string>
     <string name="time_years_ago">%dy</string>
-    <string name="managed_by_lawnchair">Lawnchair에서 관리</string>
+    <string name="managed_by_lawnchair">AI 보조에서 관리</string>
     <!-- When mentioning settings UI -->
     <string name="smartspace_preferences">설정</string>
     <string name="settings_button_text">홈 화면 설정</string>
@@ -69,7 +69,7 @@
     <string name="title_change_settings">설정 변경</string>
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout AI 보조
 
     -->
     <string name="others_category_label">기타</string>
@@ -114,7 +114,7 @@
     <string name="folders_filter_duplicates">중복 앱 숨기기</string>
     <string name="my_folder_label">내 폴더</string>
     <!-- A11y description -->
-    <string name="accessibility_service_description">특정 액션들 (휴대전화 잠그기 같은 액션)을 제스처로 발동시키려면, Lawnchair 가 접근성 기능에 접근해야 합니다. \n\nLawnchair 는 접근성 기능을 필요로 하지만 사용자의 활동을 감시하지 않으며, 시스템에서 발송된 모든 이벤트는 삭제됩니다. \n\nLawnchair 는 휴대전화를 잠그거나 최근 앱을 보기 위해서 GlobalActionAccessbility 서비스를 사용합니다.</string>
+    <string name="accessibility_service_description">특정 액션들 (휴대전화 잠그기 같은 액션)을 제스처로 발동시키려면, AI 보조 가 접근성 기능에 접근해야 합니다. \n\nAI 보조 는 접근성 기능을 필요로 하지만 사용자의 활동을 감시하지 않으며, 시스템에서 발송된 모든 이벤트는 삭제됩니다. \n\nAI 보조 는 휴대전화를 잠그거나 최근 앱을 보기 위해서 GlobalActionAccessbility 서비스를 사용합니다.</string>
     <string name="x_with_y_count">%1$s (%2$d)</string>
     <string name="x_by_y">%1$d x %2$d</string>
     <string name="x_and_y">%1$s 및 %2$s</string>
@@ -143,7 +143,7 @@
     <string name="quickstep_description">모두 닫기 버튼, 가장자리 둥글기</string>
     <string name="about_label">더 보기</string>
     <string name="app_info_drop_target_label">앱 정보</string>
-    <string name="debug_restart_launcher">Lawnchair 재시작</string>
+    <string name="debug_restart_launcher">AI 보조 재시작</string>
     <string name="experimental_features_label">실험적 기능</string>
     <!-- Experimental features -->
     <string name="font_picker_label">글꼴 사용자 정의</string>
@@ -171,7 +171,7 @@
     Notifications
 
     -->
-    <string name="set_default_launcher_tip">바로 가기 및 추가 기능에 액세스하려면 Lawnchair를 기본 홈 앱으로 설정하세요.</string>
+    <string name="set_default_launcher_tip">바로 가기 및 추가 기능에 액세스하려면 AI 보조를 기본 홈 앱으로 설정하세요.</string>
     <string name="notification_dots">알림 배지</string>
     <string name="show_notification_count">알림 개수 표시</string>
     <string name="notification_dots_color">알림 배지 색상</string>
@@ -344,7 +344,7 @@
     <string name="event_provider_missing_notification_dots"><xliff:g example="My Provider" id="providerName">%1$s</xliff:g>를 사용하려면 알림 배지를 활성화하세요.</string>
     <!-- Toggle button for enabling Smartspace -->
     <string name="smartspace_widget_toggle_label">홈 화면에 표시</string>
-    <string name="smartspace_widget_toggle_description">한눈에 보기는 Lawnchair 위젯을 배치하여 수동으로 홈 화면에 추가할 수 있습니다</string>
+    <string name="smartspace_widget_toggle_description">한눈에 보기는 AI 보조 위젯을 배치하여 수동으로 홈 화면에 추가할 수 있습니다</string>
     <!-- List of available providers -->
     <string name="smartspace_mode_label">한 눈에 보기 제공자</string>
     <string name="smartspace_mode_google">Google</string>
@@ -415,18 +415,18 @@
     <string name="gesture_handler_open_assistant">어시스턴트 열기</string>
     <string name="pick_app_for_gesture">앱 선택</string>
     <string name="dt2s_admin_hint_title">관리자 권한이 필요합니다</string>
-    <string name="dt2s_admin_hint">두 번 눌러 화면 끄기 기능을 사용하려면, Lawnchair 앱을 기기 관리자 앱으로 할당 받아야 합니다. \"설정 열기\"를 누른 후, \"이 기기 관리자 앱 활성화\"를 누르세요.</string>
+    <string name="dt2s_admin_hint">두 번 눌러 화면 끄기 기능을 사용하려면, AI 보조 앱을 기기 관리자 앱으로 할당 받아야 합니다. \"설정 열기\"를 누른 후, \"이 기기 관리자 앱 활성화\"를 누르세요.</string>
     <string name="dt2s_admin_warning">두 번 눌러 화면 끄기 기능이 비활성화됩니다.</string>
     <string name="d2ts_recents_a11y_hint_title">접근성 서비스가 활성화되어야합니다</string>
-    <string name="dt2s_a11y_hint">두 번 눌러 화면 끄기 기능을 사용하려면 Lawnchair 접근성 서비스를 사용해야 합니다. \"설정 열기\"를 눌러 나오는 화면에서 \"Lawnchair\"를 누른 뒤, \"Lawnchair 사용\"을 켜세요.\n\nLawnchair는 기기를 잠그거나 최근 앱 화면을 열기 위해 접근성 서비스의 performGlobalAction 메소드를 사용합니다. 이 메소드는 다른 앱을 감시할 수 있는 민감한 권한이지만, Lawnchair는 앱 감시 기능이 없으며 시스템에서 보내는 이벤트를 모두 무시합니다.</string>
+    <string name="dt2s_a11y_hint">두 번 눌러 화면 끄기 기능을 사용하려면 AI 보조 접근성 서비스를 사용해야 합니다. \"설정 열기\"를 눌러 나오는 화면에서 \"AI 보조\"를 누른 뒤, \"AI 보조 사용\"을 켜세요.\n\nAI 보조는 기기를 잠그거나 최근 앱 화면을 열기 위해 접근성 서비스의 performGlobalAction 메소드를 사용합니다. 이 메소드는 다른 앱을 감시할 수 있는 민감한 권한이지만, AI 보조는 앱 감시 기능이 없으며 시스템에서 보내는 이벤트를 모두 무시합니다.</string>
     <string name="dt2s_recents_warning_open_settings">설정 열기</string>
-    <string name="recents_a11y_hint">최근 앱 화면을 사용하려면 접근성 서비스에서 Lawnchair 를 켜주셔야 합니다. \"설정 열기\"를 탭하고, \"Lawnchair\"를 \"Lawnchair 사용\"으로 켜 주십시오.\n\nLawnchair 는 최근 앱 화면 열기 를 실행하는 방법으로 접근성의 `performGlobalAction`을 사용합니다. 이 권한은 다른 앱을 감시할 수 있는 민감한 권한이나, Lawnchair 는 그러한 기능이 없으며 관련된 이벤트를 받지 않습니다.</string>
+    <string name="recents_a11y_hint">최근 앱 화면을 사용하려면 접근성 서비스에서 AI 보조 를 켜주셔야 합니다. \"설정 열기\"를 탭하고, \"AI 보조\"를 \"AI 보조 사용\"으로 켜 주십시오.\n\nAI 보조 는 최근 앱 화면 열기 를 실행하는 방법으로 접근성의 `performGlobalAction`을 사용합니다. 이 권한은 다른 앱을 감시할 수 있는 민감한 권한이나, AI 보조 는 그러한 기능이 없으며 관련된 이벤트를 받지 않습니다.</string>
     <!--
 
     Bug reporting
 
     -->
-    <string name="lawnchair_bug_report">Lawnchair 버그 신고</string>
+    <string name="lawnchair_bug_report">AI 보조 버그 신고</string>
     <string name="crash_report_notif_title">%1$s가 종료되었습니다</string>
     <string name="action_upload_crash_report">크래시 로그 업로드</string>
     <string name="action_upload_error">업로드 실패</string>
@@ -519,7 +519,7 @@
     <!-- Search providers -->
     <string name="search_provider_app_search">앱 검색</string>
     <string name="search_provider_custom">개인화</string>
-    <string name="search_provider_sponsored_description">%1$s과 Lawnchair는 수익 공유 계약을 맺었습니다.\n\n%1$s로 검색하면 Lawnchair 지원에 도움이 됩니다.</string>
+    <string name="search_provider_sponsored_description">%1$s과 AI 보조는 수익 공유 계약을 맺었습니다.\n\n%1$s로 검색하면 AI 보조 지원에 도움이 됩니다.</string>
     <string name="app_label">앱</string>
     <string name="website_label">웹사이트</string>
     <string name="qsb_search_provider_app_required">앱 필요</string>
@@ -551,7 +551,7 @@
     <string name="max_folder_columns">최대 폴더 열</string>
     <string name="max_folder_rows">최대 폴더 행</string>
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">Lawnchair 가 최근 앱 보기 화면 제공자로 지정되지 않았으므로 이 설정은 무시됩니다</string>
+    <string name="quickswitch_ignored_warning">AI 보조 가 최근 앱 보기 화면 제공자로 지정되지 않았으므로 이 설정은 무시됩니다</string>
     <string name="quickstep_incompatible">호환되지 않는 시스템 통합</string>
     <string name="quickstep_incompatible_description">기기가 %1$s에서 제공하는 시스템 제스처(Quickstep으로 알려져 있음)가 설정되어 있지만 %1$s의 이 버전은 사용하고 계신 Android 버전과 호환되지 않습니다. 장치를 계속 사용하려면 %1$s 업데이트를 제거하거나 %1$s을(를) 시스템 제스처 공급자에서 비활성화하십시오.</string>
     <string name="translucent_background">반투명 배경</string>

--- a/lawnchair/res/values-ko/strings.xml
+++ b/lawnchair/res/values-ko/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI 보조
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-ku/strings.xml
+++ b/lawnchair/res/values-ku/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, Alîkarê AI
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -72,10 +72,10 @@
         <item quantity="other">%1$d Apps</item>
     </plurals>
     <string name="dt2s_admin_hint_title">Admin Permissions Required</string>
-    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set Lawnchair as a device admin app. Tap Open Settings, then tap “Activate this device admin app.”</string>
+    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set Alîkarê AI as a device admin app. Tap Open Settings, then tap “Activate this device admin app.”</string>
     <string name="dt2s_admin_warning">Double-Tap to Sleep will be turned off.</string>
     <string name="dt2s_a11y_hint_title">Turn on Accessibility Service</string>
-    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the Lawnchair accessibility service. Tap Open Settings, then select Lawnchair and turn on Use Lawnchair.</string>
+    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the Alîkarê AI accessibility service. Tap Open Settings, then select Alîkarê AI and turn on Use Alîkarê AI.</string>
     <string name="dt2s_warning_open_settings">Open Settings</string>
     <string name="minus_one_enable">Feed</string>
     <string name="minus_one_unavailable">No feed installed.</string>
@@ -105,7 +105,7 @@
     <string name="missing_notification_access_description">Notification access needed.</string>
     <string name="msg_missing_notification_access">To use Notification Dots, grant <xliff:g id="name" example="My App">%1$s</xliff:g> access to notifications.</string>
     <string name="title_change_settings">Change Settings</string>
-    <string name="debug_restart_launcher">Restart Lawnchair</string>
+    <string name="debug_restart_launcher">Restart Alîkarê AI</string>
     <string name="pref_fonts_missing_font">Font not found.</string>
     <string name="font_variant_italic">Italic</string>
     <string name="font_weight_thin">Thin</string>
@@ -144,7 +144,7 @@
     <string name="dynamic">Dynamic</string>
     <string name="all_apps_search_market_message">Search for More Apps</string>
     <string name="show_app_search_bar">Show Search Bar</string>
-    <string name="lawnchair_bug_report">Lawnchair Bug Report</string>
+    <string name="lawnchair_bug_report">Alîkarê AI Bug Report</string>
     <string name="crash_report_notif_title">%1$s Crashed</string>
     <string name="action_copy_link">Copy Link</string>
     <string name="action_copy">Copy</string>

--- a/lawnchair/res/values-ky/strings.xml
+++ b/lawnchair/res/values-ky/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI жардамчысы
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-lo/strings.xml
+++ b/lawnchair/res/values-lo/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, Ai ຜູ້ຊ່ວຍ
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-lt-rLT/strings.xml
+++ b/lawnchair/res/values-lt-rLT/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI asistentas
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@
     <string name="time_weeks_ago">%dw</string>
     <string name="time_months_ago">%dmo</string>
     <string name="time_years_ago">%dy</string>
-    <string name="managed_by_lawnchair">Valdoma „Lawnchair“</string>
+    <string name="managed_by_lawnchair">Valdoma „AI asistentas“</string>
     <!-- When mentioning settings UI -->
     <string name="smartspace_preferences">Parinktys</string>
     <string name="settings_button_text">Pagr. ekrano nustatymai</string>
@@ -69,7 +69,7 @@
     <string name="title_change_settings">Pakeisti nustatymus</string>
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout AI asistentas
 
     -->
     <string name="others_category_label">Others</string>
@@ -114,7 +114,7 @@
     <string name="folders_filter_duplicates">Only show unique apps</string>
     <string name="my_folder_label">My folder</string>
     <!-- A11y description -->
-    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, Lawnchair uses the performGlobalAction Accessibility service.</string>
+    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, AI asistentas requires accessibility access.\n\nAI asistentas doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. AI asistentas discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, AI asistentas uses the performGlobalAction Accessibility service.</string>
     <string name="x_with_y_count">%1$s (%2$d)</string>
     <string name="x_by_y">%1$d x %2$d</string>
     <string name="x_and_y">%1$s &amp; %2$s</string>
@@ -143,7 +143,7 @@
     <string name="quickstep_description">\"Išvalyti visus\" mygtukas, kampų spindulys</string>
     <string name="about_label">Apie</string>
     <string name="app_info_drop_target_label">Programėles informacija</string>
-    <string name="debug_restart_launcher">Iš Naujo Paleiskite \"Lawnchair\"</string>
+    <string name="debug_restart_launcher">Iš Naujo Paleiskite \"AI asistentas\"</string>
     <string name="experimental_features_label">Eksperimentiniai nustatymai</string>
     <!-- Experimental features -->
     <string name="font_picker_label">Šriftų tinkinimas</string>
@@ -171,7 +171,7 @@
     Notifications
 
     -->
-    <string name="set_default_launcher_tip">Norėdami naudotis nuorodomis ir papildomomis funkcijomis, nustatykite \"Lawnchair\" kaip numatytąją paleidimo programėlę</string>
+    <string name="set_default_launcher_tip">Norėdami naudotis nuorodomis ir papildomomis funkcijomis, nustatykite \"AI asistentas\" kaip numatytąją paleidimo programėlę</string>
     <string name="notification_dots">Pranešimų taškeliai</string>
     <string name="show_notification_count">Rodyti pranešimų skaičių</string>
     <string name="notification_dots_color">Pranešimo taškelio spalva</string>
@@ -344,7 +344,7 @@
     <string name="event_provider_missing_notification_dots">To use <xliff:g example="My Provider" id="providerName">%1$s</xliff:g>, turn on Notification Dots.</string>
     <!-- Toggle button for enabling Smartspace -->
     <string name="smartspace_widget_toggle_label">Rodyti pagr. ekrane</string>
-    <string name="smartspace_widget_toggle_description">„At a Glance“ pranešimų valdiklį galima pridėti rankiniu būdu, pridėjus „Lawnchair“ valdiklį</string>
+    <string name="smartspace_widget_toggle_description">„At a Glance“ pranešimų valdiklį galima pridėti rankiniu būdu, pridėjus „AI asistentas“ valdiklį</string>
     <!-- List of available providers -->
     <string name="smartspace_mode_label">„At a Glance“ teikėjas</string>
     <string name="smartspace_mode_google">Google</string>
@@ -415,18 +415,18 @@
     <string name="gesture_handler_open_assistant">Open assistant</string>
     <string name="pick_app_for_gesture">Pick app</string>
     <string name="dt2s_admin_hint_title">Admin permissions required</string>
-    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set Lawnchair as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
+    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set AI asistentas as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
     <string name="dt2s_admin_warning">Dvigubas paspaudimas miegojimui bus išjungtas.</string>
     <string name="d2ts_recents_a11y_hint_title">Turn on accessibility service</string>
-    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the AI asistentas accessibility service. Tap \"Open settings\", select \"AI asistentas\" and turn on \"Use AI asistentas.\"\n\nAI asistentas uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, AI asistentas is not configured for that functionality and receives no events.</string>
     <string name="dt2s_recents_warning_open_settings">Open settings</string>
-    <string name="recents_a11y_hint">To use Open Recents screen, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="recents_a11y_hint">To use Open Recents screen, turn on the AI asistentas accessibility service. Tap \"Open settings\", select \"AI asistentas\" and turn on \"Use AI asistentas.\"\n\nAI asistentas uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, AI asistentas is not configured for that functionality and receives no events.</string>
     <!--
 
     Bug reporting
 
     -->
-    <string name="lawnchair_bug_report">Lawnchair bug report</string>
+    <string name="lawnchair_bug_report">AI asistentas bug report</string>
     <string name="crash_report_notif_title">%1$s crashed</string>
     <string name="action_upload_crash_report">Upload crash log</string>
     <string name="action_upload_error">Nepavyko įkelti</string>
@@ -519,7 +519,7 @@
     <!-- Search providers -->
     <string name="search_provider_app_search">App search</string>
     <string name="search_provider_custom">Pasirinktinis</string>
-    <string name="search_provider_sponsored_description">%1$s and Lawnchair have a revenue share agreement.\n\nSearching with %1$s helps support Lawnchair.</string>
+    <string name="search_provider_sponsored_description">%1$s and AI asistentas have a revenue share agreement.\n\nSearching with %1$s helps support AI asistentas.</string>
     <string name="app_label">Programėlė</string>
     <string name="website_label">Interneto Svetainė</string>
     <string name="qsb_search_provider_app_required">Reikalinga programėlė</string>
@@ -554,7 +554,7 @@
     <string name="max_folder_columns">Maximum folder columns</string>
     <string name="max_folder_rows">Maximum folder rows</string>
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">These settings will be ignored as Lawnchair isn\'t set as the Recents screen provider</string>
+    <string name="quickswitch_ignored_warning">These settings will be ignored as AI asistentas isn\'t set as the Recents screen provider</string>
     <string name="quickstep_incompatible">Incompatible system integration</string>
     <string name="quickstep_incompatible_description">Your device is configured to have system gestures (known as Quickstep) provided by %1$s, but this version of %1$s isn\'t compatible with your Android version. To continue using your device, please uninstall %1$s updates or disable %1$s as a system gesture provider.</string>
     <string name="translucent_background">Translucent background</string>

--- a/lawnchair/res/values-lt/strings.xml
+++ b/lawnchair/res/values-lt/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI asistentas
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-luo/strings.xml
+++ b/lawnchair/res/values-luo/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2022, Lawnchair
+  ~ Copyright 2022, Jakony AIs
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-lv/strings.xml
+++ b/lawnchair/res/values-lv/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI palīgs
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-mk/strings.xml
+++ b/lawnchair/res/values-mk/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, Аи асистент
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-ml-rIN/strings.xml
+++ b/lawnchair/res/values-ml-rIN/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI അസിസ്റ്റന്റ്
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -69,7 +69,7 @@
     <string name="title_change_settings">ക്രമീകരണങ്ങൾ മാറ്റുക</string>
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout AI അസിസ്റ്റന്റ്
 
     -->
     <string name="others_category_label">മറ്റുള്ളവ</string>
@@ -114,7 +114,7 @@
     <string name="folders_filter_duplicates">അദ്വിതീയ ആപ്പുകൾ മാത്രം കാണിക്കുക</string>
     <string name="my_folder_label">എന്റെ ഫോൾഡർ</string>
     <!-- A11y description -->
-    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, Lawnchair uses the performGlobalAction Accessibility service.</string>
+    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, AI അസിസ്റ്റന്റ് requires accessibility access.\n\nAI അസിസ്റ്റന്റ് doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. AI അസിസ്റ്റന്റ് discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, AI അസിസ്റ്റന്റ് uses the performGlobalAction Accessibility service.</string>
     <string name="x_with_y_count">%1$s (%2$d)</string>
     <string name="x_by_y">%1$d x %2$d</string>
     <string name="x_and_y">%1$s &amp; %2$s</string>
@@ -171,7 +171,7 @@
     Notifications
 
     -->
-    <string name="set_default_launcher_tip">To access shortcuts and additional features, set Lawnchair as your default launcher</string>
+    <string name="set_default_launcher_tip">To access shortcuts and additional features, set AI അസിസ്റ്റന്റ് as your default launcher</string>
     <string name="notification_dots">Notification dots</string>
     <string name="show_notification_count">Show notification counter</string>
     <string name="notification_dots_color">Notification dot color</string>
@@ -344,7 +344,7 @@
     <string name="event_provider_missing_notification_dots">To use <xliff:g example="My Provider" id="providerName">%1$s</xliff:g>, turn on Notification Dots.</string>
     <!-- Toggle button for enabling Smartspace -->
     <string name="smartspace_widget_toggle_label">Show on home screen</string>
-    <string name="smartspace_widget_toggle_description">At a Glance can be manually added to the home screen by placing the Lawnchair widget</string>
+    <string name="smartspace_widget_toggle_description">At a Glance can be manually added to the home screen by placing the AI അസിസ്റ്റന്റ് widget</string>
     <!-- List of available providers -->
     <string name="smartspace_mode_label">At a Glance provider</string>
     <string name="smartspace_mode_google">Google</string>
@@ -415,18 +415,18 @@
     <string name="gesture_handler_open_assistant">Open assistant</string>
     <string name="pick_app_for_gesture">Pick app</string>
     <string name="dt2s_admin_hint_title">Admin permissions required</string>
-    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set Lawnchair as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
+    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set AI അസിസ്റ്റന്റ് as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
     <string name="dt2s_admin_warning">ഉറങ്ങാൻ രണ്ടുതവണ ടാപ്പ് ചെയ്യുന്നത് ഓഫാകും.</string>
     <string name="d2ts_recents_a11y_hint_title">Turn on accessibility service</string>
-    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the AI അസിസ്റ്റന്റ് accessibility service. Tap \"Open settings\", select \"AI അസിസ്റ്റന്റ്\" and turn on \"Use AI അസിസ്റ്റന്റ്.\"\n\nAI അസിസ്റ്റന്റ് uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, AI അസിസ്റ്റന്റ് is not configured for that functionality and receives no events.</string>
     <string name="dt2s_recents_warning_open_settings">Open settings</string>
-    <string name="recents_a11y_hint">To use Open Recents screen, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="recents_a11y_hint">To use Open Recents screen, turn on the AI അസിസ്റ്റന്റ് accessibility service. Tap \"Open settings\", select \"AI അസിസ്റ്റന്റ്\" and turn on \"Use AI അസിസ്റ്റന്റ്.\"\n\nAI അസിസ്റ്റന്റ് uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, AI അസിസ്റ്റന്റ് is not configured for that functionality and receives no events.</string>
     <!--
 
     Bug reporting
 
     -->
-    <string name="lawnchair_bug_report">Lawnchair bug report</string>
+    <string name="lawnchair_bug_report">AI അസിസ്റ്റന്റ് bug report</string>
     <string name="crash_report_notif_title">%1$s crashed</string>
     <string name="action_upload_crash_report">Upload crash log</string>
     <string name="action_upload_error">അപ്‌ലോഡ് പരാജയപ്പെട്ടു</string>
@@ -519,7 +519,7 @@
     <!-- Search providers -->
     <string name="search_provider_app_search">App search</string>
     <string name="search_provider_custom">ഇഷ്ടാനുസൃതം</string>
-    <string name="search_provider_sponsored_description">%1$s and Lawnchair have a revenue share agreement.\n\nSearching with %1$s helps support Lawnchair.</string>
+    <string name="search_provider_sponsored_description">%1$s and AI അസിസ്റ്റന്റ് have a revenue share agreement.\n\nSearching with %1$s helps support AI അസിസ്റ്റന്റ്.</string>
     <string name="app_label">App</string>
     <string name="website_label">Website</string>
     <string name="qsb_search_provider_app_required">App required</string>
@@ -552,7 +552,7 @@
     <string name="max_folder_columns">Maximum folder columns</string>
     <string name="max_folder_rows">Maximum folder rows</string>
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">These settings will be ignored as Lawnchair isn\'t set as the Recents screen provider</string>
+    <string name="quickswitch_ignored_warning">These settings will be ignored as AI അസിസ്റ്റന്റ് isn\'t set as the Recents screen provider</string>
     <string name="quickstep_incompatible">Incompatible system integration</string>
     <string name="quickstep_incompatible_description">Your device is configured to have system gestures (known as Quickstep) provided by %1$s, but this version of %1$s isn\'t compatible with your Android version. To continue using your device, please uninstall %1$s updates or disable %1$s as a system gesture provider.</string>
     <string name="translucent_background">Translucent background</string>

--- a/lawnchair/res/values-ml/strings.xml
+++ b/lawnchair/res/values-ml/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI അസിസ്റ്റന്റ്
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-mn/strings.xml
+++ b/lawnchair/res/values-mn/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI туслах
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-mr-rIN/strings.xml
+++ b/lawnchair/res/values-mr-rIN/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, एआय सहाय्यक
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -69,7 +69,7 @@
     <string name="title_change_settings">Change settings</string>
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout एआय सहाय्यक
 
     -->
     <string name="others_category_label">Others</string>
@@ -114,7 +114,7 @@
     <string name="folders_filter_duplicates">Only show unique apps</string>
     <string name="my_folder_label">My folder</string>
     <!-- A11y description -->
-    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, Lawnchair uses the performGlobalAction Accessibility service.</string>
+    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, एआय सहाय्यक requires accessibility access.\n\nएआय सहाय्यक doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. एआय सहाय्यक discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, एआय सहाय्यक uses the performGlobalAction Accessibility service.</string>
     <string name="x_with_y_count">%1$s (%2$d)</string>
     <string name="x_by_y">%1$d x %2$d</string>
     <string name="x_and_y">%1$s &amp; %2$s</string>
@@ -171,7 +171,7 @@
     Notifications
 
     -->
-    <string name="set_default_launcher_tip">To access shortcuts and additional features, set Lawnchair as your default launcher</string>
+    <string name="set_default_launcher_tip">To access shortcuts and additional features, set एआय सहाय्यक as your default launcher</string>
     <string name="notification_dots">Notification dots</string>
     <string name="show_notification_count">Show notification counter</string>
     <string name="notification_dots_color">Notification dot color</string>
@@ -344,7 +344,7 @@
     <string name="event_provider_missing_notification_dots">To use <xliff:g example="My Provider" id="providerName">%1$s</xliff:g>, turn on Notification Dots.</string>
     <!-- Toggle button for enabling Smartspace -->
     <string name="smartspace_widget_toggle_label">Show on home screen</string>
-    <string name="smartspace_widget_toggle_description">At a Glance can be manually added to the home screen by placing the Lawnchair widget</string>
+    <string name="smartspace_widget_toggle_description">At a Glance can be manually added to the home screen by placing the एआय सहाय्यक widget</string>
     <!-- List of available providers -->
     <string name="smartspace_mode_label">At a Glance provider</string>
     <string name="smartspace_mode_google">Google</string>
@@ -415,18 +415,18 @@
     <string name="gesture_handler_open_assistant">Open assistant</string>
     <string name="pick_app_for_gesture">Pick app</string>
     <string name="dt2s_admin_hint_title">Admin permissions required</string>
-    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set Lawnchair as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
+    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set एआय सहाय्यक as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
     <string name="dt2s_admin_warning">Double-Tap to Sleep will be turned off.</string>
     <string name="d2ts_recents_a11y_hint_title">Turn on accessibility service</string>
-    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the एआय सहाय्यक accessibility service. Tap \"Open settings\", select \"एआय सहाय्यक\" and turn on \"Use एआय सहाय्यक.\"\n\nएआय सहाय्यक uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, एआय सहाय्यक is not configured for that functionality and receives no events.</string>
     <string name="dt2s_recents_warning_open_settings">Open settings</string>
-    <string name="recents_a11y_hint">To use Open Recents screen, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="recents_a11y_hint">To use Open Recents screen, turn on the एआय सहाय्यक accessibility service. Tap \"Open settings\", select \"एआय सहाय्यक\" and turn on \"Use एआय सहाय्यक.\"\n\nएआय सहाय्यक uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, एआय सहाय्यक is not configured for that functionality and receives no events.</string>
     <!--
 
     Bug reporting
 
     -->
-    <string name="lawnchair_bug_report">Lawnchair bug report</string>
+    <string name="lawnchair_bug_report">एआय सहाय्यक bug report</string>
     <string name="crash_report_notif_title">%1$s crashed</string>
     <string name="action_upload_crash_report">Upload crash log</string>
     <string name="action_upload_error">Upload failed</string>
@@ -519,7 +519,7 @@
     <!-- Search providers -->
     <string name="search_provider_app_search">App search</string>
     <string name="search_provider_custom">Custom</string>
-    <string name="search_provider_sponsored_description">%1$s and Lawnchair have a revenue share agreement.\n\nSearching with %1$s helps support Lawnchair.</string>
+    <string name="search_provider_sponsored_description">%1$s and एआय सहाय्यक have a revenue share agreement.\n\nSearching with %1$s helps support एआय सहाय्यक.</string>
     <string name="app_label">App</string>
     <string name="website_label">Website</string>
     <string name="qsb_search_provider_app_required">App required</string>
@@ -552,7 +552,7 @@
     <string name="max_folder_columns">Maximum folder columns</string>
     <string name="max_folder_rows">Maximum folder rows</string>
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">These settings will be ignored as Lawnchair isn\'t set as the Recents screen provider</string>
+    <string name="quickswitch_ignored_warning">These settings will be ignored as एआय सहाय्यक isn\'t set as the Recents screen provider</string>
     <string name="quickstep_incompatible">Incompatible system integration</string>
     <string name="quickstep_incompatible_description">Your device is configured to have system gestures (known as Quickstep) provided by %1$s, but this version of %1$s isn\'t compatible with your Android version. To continue using your device, please uninstall %1$s updates or disable %1$s as a system gesture provider.</string>
     <string name="translucent_background">Translucent background</string>

--- a/lawnchair/res/values-mr/strings.xml
+++ b/lawnchair/res/values-mr/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, एआय सहाय्यक
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-ms/strings.xml
+++ b/lawnchair/res/values-ms/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, Pembantu AI
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-my/strings.xml
+++ b/lawnchair/res/values-my/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI လက်ထောက်
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-nb/strings.xml
+++ b/lawnchair/res/values-nb/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI -assistent
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-ne/strings.xml
+++ b/lawnchair/res/values-ne/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, ऐ सहायक
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-nl-rNL/strings.xml
+++ b/lawnchair/res/values-nl-rNL/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI -assistent
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@
     <string name="time_weeks_ago">%dw</string>
     <string name="time_months_ago">%dmo</string>
     <string name="time_years_ago">%dy</string>
-    <string name="managed_by_lawnchair">Beheerd door Lawnchair</string>
+    <string name="managed_by_lawnchair">Beheerd door AI -assistent</string>
     <!-- When mentioning settings UI -->
     <string name="smartspace_preferences">Voorkeuren</string>
     <string name="settings_button_text">Instellingen voor startscherm</string>
@@ -69,7 +69,7 @@
     <string name="title_change_settings">Instellingen wijzigen</string>
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout AI -assistent
 
     -->
     <string name="others_category_label">Overige</string>
@@ -114,7 +114,7 @@
     <string name="folders_filter_duplicates">Alleen unieke apps tonen</string>
     <string name="my_folder_label">Mijn map</string>
     <!-- A11y description -->
-    <string name="accessibility_service_description">Om bepaalde acties uit te voeren (zoals het vergrendelen van je telefoon) bij het uitvoeren van een gebaar, heeft Lawnchair toegang tot toegankelijkheid nodig.\n\nLawnchair observeert echter geen gebruikersacties, hoewel de bevoegdheid om dat te doen vereist is voor alle toegankelijkheidsdiensten. Lawnchair negeert elke gebeurtenis die door het systeem wordt gemeld.\n\nOm je telefoon te vergrendelen of om het recente scherm te openen, maakt Lawnchair gebruik van de toegankelijkheidsdienst performGlobalAction.</string>
+    <string name="accessibility_service_description">Om bepaalde acties uit te voeren (zoals het vergrendelen van je telefoon) bij het uitvoeren van een gebaar, heeft AI -assistent toegang tot toegankelijkheid nodig.\n\nAI -assistent observeert echter geen gebruikersacties, hoewel de bevoegdheid om dat te doen vereist is voor alle toegankelijkheidsdiensten. AI -assistent negeert elke gebeurtenis die door het systeem wordt gemeld.\n\nOm je telefoon te vergrendelen of om het recente scherm te openen, maakt AI -assistent gebruik van de toegankelijkheidsdienst performGlobalAction.</string>
     <string name="x_with_y_count">%1$s (%2$d)</string>
     <string name="x_by_y">%1$d x %2$d</string>
     <string name="x_and_y">%1$s &amp; %2$s</string>
@@ -143,7 +143,7 @@
     <string name="quickstep_description">Knop Alles wissen, hoekradius</string>
     <string name="about_label">Over</string>
     <string name="app_info_drop_target_label">App-informatie</string>
-    <string name="debug_restart_launcher">Lawnchair opnieuw starten</string>
+    <string name="debug_restart_launcher">AI -assistent opnieuw starten</string>
     <string name="experimental_features_label">Experimentele functies</string>
     <!-- Experimental features -->
     <string name="font_picker_label">Lettertype-aanpassingen</string>
@@ -171,7 +171,7 @@
     Notifications
 
     -->
-    <string name="set_default_launcher_tip">Stel Lawnchair in als standaard launcher voor toegang tot snelkoppelingen en extra functies</string>
+    <string name="set_default_launcher_tip">Stel AI -assistent in als standaard launcher voor toegang tot snelkoppelingen en extra functies</string>
     <string name="notification_dots">Meldingsstippen</string>
     <string name="show_notification_count">Aantal meldingen weergeven</string>
     <string name="notification_dots_color">Meldingsstip-kleur</string>
@@ -344,7 +344,7 @@
     <string name="event_provider_missing_notification_dots">Schakel meldingsstippen in om <xliff:g example="My Provider" id="providerName">%1$s</xliff:g>te gebruiken.</string>
     <!-- Toggle button for enabling Smartspace -->
     <string name="smartspace_widget_toggle_label">Weergeven op startscherm</string>
-    <string name="smartspace_widget_toggle_description">At a Glance kan handmatig aan het startscherm worden toegevoegd door de “Lawnchair ” widget te plaatsen</string>
+    <string name="smartspace_widget_toggle_description">At a Glance kan handmatig aan het startscherm worden toegevoegd door de “AI -assistent ” widget te plaatsen</string>
     <!-- List of available providers -->
     <string name="smartspace_mode_label">At a Glance provider</string>
     <string name="smartspace_mode_google">Google</string>
@@ -415,18 +415,18 @@
     <string name="gesture_handler_open_assistant">Assistent openen</string>
     <string name="pick_app_for_gesture">App kiezen</string>
     <string name="dt2s_admin_hint_title">Beheerdersrechten vereist</string>
-    <string name="dt2s_admin_hint">Om Dubbeltikken voor Slaapstand te gebruiken, moet Lawnchair worden ingesteld als een apparaatbeheerder-app. Tik op \"Instellingen openen\" en tik vervolgens op \"Activeer deze apparaatbeheerder-app.\"</string>
+    <string name="dt2s_admin_hint">Om Dubbeltikken voor Slaapstand te gebruiken, moet AI -assistent worden ingesteld als een apparaatbeheerder-app. Tik op \"Instellingen openen\" en tik vervolgens op \"Activeer deze apparaatbeheerder-app.\"</string>
     <string name="dt2s_admin_warning">Dubbeltikken voor Slaapstand wordt uitgeschakeld.</string>
     <string name="d2ts_recents_a11y_hint_title">Toegankelijkheidsservice inschakelen</string>
-    <string name="dt2s_a11y_hint">Om \'Dubbel tikken om in de sluimerstand te zetten\' te gebruiken, moet de toegankelijkheidsservice Lawnchair ingeschakeld zijn. Tik op \"Instellingen openen\", selecteer \"Lawnchair\" en schakel \"Lawnchair gebruiken\" in. \n\nLawnchair gebruikt de \'performGlobalAction\'-methode van Toegankelijkheid om deze actie uit te voeren. Dit is een gevoelige machtiging waarmee andere apps kunnen worden bewaakt. Lawnchair is echter niet geconfigureerd voor die functionaliteit en ontvangt geen gebeurtenissen.</string>
+    <string name="dt2s_a11y_hint">Om \'Dubbel tikken om in de sluimerstand te zetten\' te gebruiken, moet de toegankelijkheidsservice AI -assistent ingeschakeld zijn. Tik op \"Instellingen openen\", selecteer \"AI -assistent\" en schakel \"AI -assistent gebruiken\" in. \n\nAI -assistent gebruikt de \'performGlobalAction\'-methode van Toegankelijkheid om deze actie uit te voeren. Dit is een gevoelige machtiging waarmee andere apps kunnen worden bewaakt. AI -assistent is echter niet geconfigureerd voor die functionaliteit en ontvangt geen gebeurtenissen.</string>
     <string name="dt2s_recents_warning_open_settings">Instellingen openen</string>
-    <string name="recents_a11y_hint">Om het scherm \'Recente apps openen\' te gebruiken, dient de toegankelijkheidsservice van Lawnchair ingeschakeld te worden. Tik op \'Instellingen openen\', selecteer \'Lawnchair\' en activeer \'Gebruik Lawnchair\'.\n\nLawnchair gebruikt de toegankelijkheidsmethode `performGlobalAction` om deze actie uit te voeren. Dit is een gevoelige toestemming die het mogelijk maakt om andere apps te controleren. Lawnchair is echter niet geconfigureerd voor die functionaliteit en ontvangt geen gebeurtenissen.</string>
+    <string name="recents_a11y_hint">Om het scherm \'Recente apps openen\' te gebruiken, dient de toegankelijkheidsservice van AI -assistent ingeschakeld te worden. Tik op \'Instellingen openen\', selecteer \'AI -assistent\' en activeer \'Gebruik AI -assistent\'.\n\nAI -assistent gebruikt de toegankelijkheidsmethode `performGlobalAction` om deze actie uit te voeren. Dit is een gevoelige toestemming die het mogelijk maakt om andere apps te controleren. AI -assistent is echter niet geconfigureerd voor die functionaliteit en ontvangt geen gebeurtenissen.</string>
     <!--
 
     Bug reporting
 
     -->
-    <string name="lawnchair_bug_report">Lawnchair foutrapportage</string>
+    <string name="lawnchair_bug_report">AI -assistent foutrapportage</string>
     <string name="crash_report_notif_title">%1$s is gecrasht</string>
     <string name="action_upload_crash_report">Crash-logboek uploaden</string>
     <string name="action_upload_error">Uploaden mislukt</string>
@@ -519,7 +519,7 @@
     <!-- Search providers -->
     <string name="search_provider_app_search">App zoeken</string>
     <string name="search_provider_custom">Aangepast</string>
-    <string name="search_provider_sponsored_description">%1$s en Lawnchair hebben een overeenkomst a.g. het delen van inkomsten.\n\nZoeken met %1$s helpt Lawnchair te ondersteunen.</string>
+    <string name="search_provider_sponsored_description">%1$s en AI -assistent hebben een overeenkomst a.g. het delen van inkomsten.\n\nZoeken met %1$s helpt AI -assistent te ondersteunen.</string>
     <string name="app_label">App</string>
     <string name="website_label">Website</string>
     <string name="qsb_search_provider_app_required">App vereist</string>
@@ -552,7 +552,7 @@
     <string name="max_folder_columns">Maximum aantal mapkolommen</string>
     <string name="max_folder_rows">Maximum aantal maprijen</string>
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">Deze instellingen worden genegeerd omdat Lawnchair niet is ingesteld als de leverancier voor het scherm Recente apps</string>
+    <string name="quickswitch_ignored_warning">Deze instellingen worden genegeerd omdat AI -assistent niet is ingesteld als de leverancier voor het scherm Recente apps</string>
     <string name="quickstep_incompatible">Incompatibele systeemintegratie</string>
     <string name="quickstep_incompatible_description">Je toestel is geconfigureerd voor systeemgebaren (bekend als Quickstep) geleverd door %1$s, maar deze versie van %1$s is niet compatibel met deze Android-versie. Om het toestel te blijven gebruiken, dien je %1$s updates te verwijderen of %1$s uit te schakelen als een provider van systeemgebaren.</string>
     <string name="translucent_background">Doorschijnende achtergrond</string>

--- a/lawnchair/res/values-nl/strings.xml
+++ b/lawnchair/res/values-nl/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI -assistent
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-no-rNO/strings.xml
+++ b/lawnchair/res/values-no-rNO/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI -assistent
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@
     <string name="time_weeks_ago">%dw</string>
     <string name="time_months_ago">%dmo</string>
     <string name="time_years_ago">%dy</string>
-    <string name="managed_by_lawnchair">Styrt av Lawnchair</string>
+    <string name="managed_by_lawnchair">Styrt av AI -assistent</string>
     <!-- When mentioning settings UI -->
     <string name="smartspace_preferences">Preferanser</string>
     <string name="settings_button_text">Hjem-innstillinger</string>
@@ -69,7 +69,7 @@
     <string name="title_change_settings">Endre innstillinger</string>
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout AI -assistent
 
     -->
     <string name="others_category_label">Others</string>
@@ -114,7 +114,7 @@
     <string name="folders_filter_duplicates">Only show unique apps</string>
     <string name="my_folder_label">My folder</string>
     <!-- A11y description -->
-    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, Lawnchair uses the performGlobalAction Accessibility service.</string>
+    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, AI -assistent requires accessibility access.\n\nAI -assistent doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. AI -assistent discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, AI -assistent uses the performGlobalAction Accessibility service.</string>
     <string name="x_with_y_count">%1$s (%2$d)</string>
     <string name="x_by_y">%1$d x %2$d</string>
     <string name="x_and_y">%1$s &amp; %2$s</string>
@@ -143,7 +143,7 @@
     <string name="quickstep_description">Fjern alt knapp, hjørneradius</string>
     <string name="about_label">Om</string>
     <string name="app_info_drop_target_label">App info</string>
-    <string name="debug_restart_launcher">Omstart av Lawnchair</string>
+    <string name="debug_restart_launcher">Omstart av AI -assistent</string>
     <string name="experimental_features_label">Eksperimentelle funksjoner</string>
     <!-- Experimental features -->
     <string name="font_picker_label">Endre font</string>
@@ -171,7 +171,7 @@
     Notifications
 
     -->
-    <string name="set_default_launcher_tip">For å få tilgang til snarveier og ytterligere funksjoner sett Lawnchair som standard appvelger</string>
+    <string name="set_default_launcher_tip">For å få tilgang til snarveier og ytterligere funksjoner sett AI -assistent som standard appvelger</string>
     <string name="notification_dots">Prikker for varsling</string>
     <string name="show_notification_count">Vis antall varsler</string>
     <string name="notification_dots_color">Farge for varselprikk</string>
@@ -344,7 +344,7 @@
     <string name="event_provider_missing_notification_dots">For å bruke <xliff:g example="My Provider" id="providerName">%1$s</xliff:g>, slå på Prikker for varsling. </string>
     <!-- Toggle button for enabling Smartspace -->
     <string name="smartspace_widget_toggle_label">Vis på hjemmeskjerm</string>
-    <string name="smartspace_widget_toggle_description">Hurtig overblikk kan manuelt legges til hjemskjerm ved å placere Lawnchair widgeten</string>
+    <string name="smartspace_widget_toggle_description">Hurtig overblikk kan manuelt legges til hjemskjerm ved å placere AI -assistent widgeten</string>
     <!-- List of available providers -->
     <string name="smartspace_mode_label">Hurtig overblikkstilbyder</string>
     <string name="smartspace_mode_google">Google</string>
@@ -415,18 +415,18 @@
     <string name="gesture_handler_open_assistant">Open assistant</string>
     <string name="pick_app_for_gesture">Velg app</string>
     <string name="dt2s_admin_hint_title">Administratortilgang er nødvendig</string>
-    <string name="dt2s_admin_hint">For å bruke dobbelt-tapping for å sove, sett Lawnchair som enhetsadministrator app. Trykk på \"åpne instillinger\", trykk på \"Aktiver denne app som enhetsadministrator\"</string>
+    <string name="dt2s_admin_hint">For å bruke dobbelt-tapping for å sove, sett AI -assistent som enhetsadministrator app. Trykk på \"åpne instillinger\", trykk på \"Aktiver denne app som enhetsadministrator\"</string>
     <string name="dt2s_admin_warning">Dobbeltrykk for å slukke vil bli slått av.</string>
     <string name="d2ts_recents_a11y_hint_title">Slå på tilgjengelighetsservice</string>
-    <string name="dt2s_a11y_hint">For å bruke dobbelt-tapping for å sove, slå på tilgjengelighetstjenesten for Lawnchair. Trykk på \"Åpne innstillinger\", velg \"Lawnchair\" og slå på \"Bruk Lawnchair.\" \n\nLawnchair bruker tilgjengelighets \'performGlobalAction\'-metode for å utføre denne handlingen. Dette er en sensitiv tillatelse som gjør det mulig å overvåke andre apper. Lawnchair er imidlertid ikke konfigurert for denne funksjonaliteten og mottar ingen hendelser.</string>
+    <string name="dt2s_a11y_hint">For å bruke dobbelt-tapping for å sove, slå på tilgjengelighetstjenesten for AI -assistent. Trykk på \"Åpne innstillinger\", velg \"AI -assistent\" og slå på \"Bruk AI -assistent.\" \n\nAI -assistent bruker tilgjengelighets \'performGlobalAction\'-metode for å utføre denne handlingen. Dette er en sensitiv tillatelse som gjør det mulig å overvåke andre apper. AI -assistent er imidlertid ikke konfigurert for denne funksjonaliteten og mottar ingen hendelser.</string>
     <string name="dt2s_recents_warning_open_settings">Åpne instillinger</string>
-    <string name="recents_a11y_hint">To use Open Recents screen, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="recents_a11y_hint">To use Open Recents screen, turn on the AI -assistent accessibility service. Tap \"Open settings\", select \"AI -assistent\" and turn on \"Use AI -assistent.\"\n\nAI -assistent uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, AI -assistent is not configured for that functionality and receives no events.</string>
     <!--
 
     Bug reporting
 
     -->
-    <string name="lawnchair_bug_report">Lawnchair feilrapport</string>
+    <string name="lawnchair_bug_report">AI -assistent feilrapport</string>
     <string name="crash_report_notif_title">%1$s krasjet</string>
     <string name="action_upload_crash_report">Last opp krasjlog</string>
     <string name="action_upload_error">Opplasting feilet</string>
@@ -519,7 +519,7 @@
     <!-- Search providers -->
     <string name="search_provider_app_search">Appsøk</string>
     <string name="search_provider_custom">Tilpasset</string>
-    <string name="search_provider_sponsored_description">%1$s og Lawnchair har en inntektsdelingsavtale.\n\nÅ søke med %1$s hjelper til med å støtte Lawnchair.</string>
+    <string name="search_provider_sponsored_description">%1$s og AI -assistent har en inntektsdelingsavtale.\n\nÅ søke med %1$s hjelper til med å støtte AI -assistent.</string>
     <string name="app_label">App</string>
     <string name="website_label">Nettside</string>
     <string name="qsb_search_provider_app_required">App påkrevd</string>
@@ -552,7 +552,7 @@
     <string name="max_folder_columns">Maksimalt antall mappekolonner</string>
     <string name="max_folder_rows">Maksimum mapperader</string>
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">These settings will be ignored as Lawnchair isn\'t set as the Recents screen provider</string>
+    <string name="quickswitch_ignored_warning">These settings will be ignored as AI -assistent isn\'t set as the Recents screen provider</string>
     <string name="quickstep_incompatible">Ukompatibel systemintegrering</string>
     <string name="quickstep_incompatible_description">Enheten din er konfigurert til å ha systembevegelser (kjent som Quickstep) levert av %1$s, men denne versjonen av %1$s er ikke kompatibel med Android-versjonen din. Hvis du vil fortsette å bruke enheten, må du avinstallere %1$s-oppdateringer eller deaktivere %1$s som leverandør av systembevegelser.</string>
     <string name="translucent_background">Gjennomskinn bakgrunn</string>

--- a/lawnchair/res/values-or/strings.xml
+++ b/lawnchair/res/values-or/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI ସହାୟକ
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-pa/strings.xml
+++ b/lawnchair/res/values-pa/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, ਏਆਈ ਸਹਾਇਕ
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-pl-rPL/strings.xml
+++ b/lawnchair/res/values-pl-rPL/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AII Asystent
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@
     <string name="time_weeks_ago">%dw</string>
     <string name="time_months_ago">%dmo</string>
     <string name="time_years_ago">%dy</string>
-    <string name="managed_by_lawnchair">Zarządzane przez Lawnchair</string>
+    <string name="managed_by_lawnchair">Zarządzane przez AII Asystent</string>
     <!-- When mentioning settings UI -->
     <string name="smartspace_preferences">Ustawienia</string>
     <string name="settings_button_text">Ustawienia ekranu głównego</string>
@@ -69,7 +69,7 @@
     <string name="title_change_settings">Zmień ustawienia</string>
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout AII Asystent
 
     -->
     <string name="others_category_label">Inne</string>
@@ -114,7 +114,7 @@
     <string name="folders_filter_duplicates">Pokaż tylko niedodane aplikacje</string>
     <string name="my_folder_label">Mój folder</string>
     <!-- A11y description -->
-    <string name="accessibility_service_description">Aby wykonywać określone czynności (takie jak blokowanie telefonu) za pomocą gestów, aplikacja Lawnchair wymaga uprawnień dostępu do ułatwień dostępu.\n\nLawnchair nie obserwuje żadnych działań użytkownika, mimo że uprawnienie do tego jest wymagane przez wszystkie usługi ułatwień dostępu. Wszelkie zdarzenia wysyłane przez system są przez Lawnchair odrzucane.\n\nW celu zablokowania telefonu lub otwarcia ekranu Ostatnich aplikacji, Lawnchair korzysta z funkcji performGlobalAction w ramach usług ułatwień dostępu.</string>
+    <string name="accessibility_service_description">Aby wykonywać określone czynności (takie jak blokowanie telefonu) za pomocą gestów, aplikacja AII Asystent wymaga uprawnień dostępu do ułatwień dostępu.\n\nAII Asystent nie obserwuje żadnych działań użytkownika, mimo że uprawnienie do tego jest wymagane przez wszystkie usługi ułatwień dostępu. Wszelkie zdarzenia wysyłane przez system są przez AII Asystent odrzucane.\n\nW celu zablokowania telefonu lub otwarcia ekranu Ostatnich aplikacji, AII Asystent korzysta z funkcji performGlobalAction w ramach usług ułatwień dostępu.</string>
     <string name="x_with_y_count">%1$s (%2$d)</string>
     <string name="x_by_y">%1$d x %2$d</string>
     <string name="x_and_y">%1$s i %2$s</string>
@@ -143,7 +143,7 @@
     <string name="quickstep_description">Przycisk \"Wyczyść wszystko\", promień narożnika</string>
     <string name="about_label">O aplikacji</string>
     <string name="app_info_drop_target_label">Informacje o aplikacji</string>
-    <string name="debug_restart_launcher">Zrestartuj Lawnchair</string>
+    <string name="debug_restart_launcher">Zrestartuj AII Asystent</string>
     <string name="experimental_features_label">Funkcje eksperymentalne</string>
     <!-- Experimental features -->
     <string name="font_picker_label">Dostosowanie czcionki</string>
@@ -171,7 +171,7 @@
     Notifications
 
     -->
-    <string name="set_default_launcher_tip">Aby uzyskać dostęp do skrótów i dodatkowych funkcji, ustaw Lawnchair jako domyślny ekran główny</string>
+    <string name="set_default_launcher_tip">Aby uzyskać dostęp do skrótów i dodatkowych funkcji, ustaw AII Asystent jako domyślny ekran główny</string>
     <string name="notification_dots">Kropki powiadomień</string>
     <string name="show_notification_count">Pokazuj licznik powiadomień</string>
     <string name="notification_dots_color">Kolor kropki powiadomień</string>
@@ -344,7 +344,7 @@
     <string name="event_provider_missing_notification_dots">Aby używać <xliff:g example="My Provider" id="providerName">%1$s</xliff:g>, włącz kropki powiadomień.</string>
     <!-- Toggle button for enabling Smartspace -->
     <string name="smartspace_widget_toggle_label">Pokazuj na ekranie głównym</string>
-    <string name="smartspace_widget_toggle_description">Szybki Podgląd może zostać dodany ręcznie poprzez umieszczenie widżetu Lawnchair na ekranie głównym</string>
+    <string name="smartspace_widget_toggle_description">Szybki Podgląd może zostać dodany ręcznie poprzez umieszczenie widżetu AII Asystent na ekranie głównym</string>
     <!-- List of available providers -->
     <string name="smartspace_mode_label">Dostawca Szybkiego Podglądu</string>
     <string name="smartspace_mode_google">Google</string>
@@ -415,18 +415,18 @@
     <string name="gesture_handler_open_assistant">Otwórz asystenta</string>
     <string name="pick_app_for_gesture">Wybierz aplikację</string>
     <string name="dt2s_admin_hint_title">Wymagane uprawnienia administratora</string>
-    <string name="dt2s_admin_hint">Aby użyć opcji usypiania przy podwójnym naciśnięciu, ustaw Lawnchair jako aplikację administrującą urządzeniem. Naciśnij \"Otwórz ustawienia\", następnie naciśnij \"Aktywuj tę aplikację do administrowania urządzeniem.\"</string>
+    <string name="dt2s_admin_hint">Aby użyć opcji usypiania przy podwójnym naciśnięciu, ustaw AII Asystent jako aplikację administrującą urządzeniem. Naciśnij \"Otwórz ustawienia\", następnie naciśnij \"Aktywuj tę aplikację do administrowania urządzeniem.\"</string>
     <string name="dt2s_admin_warning">Opcja \"Dotknij dwa razy aby uśpić\" zostanie wyłączona.</string>
     <string name="d2ts_recents_a11y_hint_title">Włącz usługę dostępności</string>
-    <string name="dt2s_a11y_hint">Aby użyć podwójnego naciśnięcia, włącz usługę dostępności Lawnchair i kliknij \"Otwórz ustawienia\", wybierz \"Lawnchair\" i włącz \"Użyj Lawnchair.\n\nLawnchair używa metody `performGlobalAction` Dostępności do wykonania tej czynności. To jest wrażliwe uprawnienie, które pozwala na monitorowanie innych aplikacji. Lawnchair nie jest jednak skonfigurowany dla tej funkcjonalności i nie otrzymuje żadnych zdarzeń.</string>
+    <string name="dt2s_a11y_hint">Aby użyć podwójnego naciśnięcia, włącz usługę dostępności AII Asystent i kliknij \"Otwórz ustawienia\", wybierz \"AII Asystent\" i włącz \"Użyj AII Asystent.\n\nAII Asystent używa metody `performGlobalAction` Dostępności do wykonania tej czynności. To jest wrażliwe uprawnienie, które pozwala na monitorowanie innych aplikacji. AII Asystent nie jest jednak skonfigurowany dla tej funkcjonalności i nie otrzymuje żadnych zdarzeń.</string>
     <string name="dt2s_recents_warning_open_settings">Otwórz ustawienia</string>
-    <string name="recents_a11y_hint">Aby korzystać z funkcji otwierania ekranu Ostatnich aplikacji, włącz usługę ułatwień dostępu Lawnchair. Dotknij „Otwórz ustawienia”, wybierz „Lawnchair” i włącz opcję „Używaj Lawnchair”.\n\nDo wykonania tej czynności Lawnchair używa metody performGlobalAction z usług ułatwień dostępu. Jest to wrażliwe uprawnienie, które może pozwalać na monitorowanie innych aplikacji. Lawnchair nie jest jednak skonfigurowany do używania tej funkcji i nie odbiera żadnych zdarzeń systemowych.</string>
+    <string name="recents_a11y_hint">Aby korzystać z funkcji otwierania ekranu Ostatnich aplikacji, włącz usługę ułatwień dostępu AII Asystent. Dotknij „Otwórz ustawienia”, wybierz „AII Asystent” i włącz opcję „Używaj AII Asystent”.\n\nDo wykonania tej czynności AII Asystent używa metody performGlobalAction z usług ułatwień dostępu. Jest to wrażliwe uprawnienie, które może pozwalać na monitorowanie innych aplikacji. AII Asystent nie jest jednak skonfigurowany do używania tej funkcji i nie odbiera żadnych zdarzeń systemowych.</string>
     <!--
 
     Bug reporting
 
     -->
-    <string name="lawnchair_bug_report">Raport błędów Lawnchair</string>
+    <string name="lawnchair_bug_report">Raport błędów AII Asystent</string>
     <string name="crash_report_notif_title">%1$s uległ awarii</string>
     <string name="action_upload_crash_report">Prześlij dziennik awarii</string>
     <string name="action_upload_error">Nie udało się przesłać</string>
@@ -519,7 +519,7 @@
     <!-- Search providers -->
     <string name="search_provider_app_search">Wyszukiwanie aplikacji</string>
     <string name="search_provider_custom">Własny</string>
-    <string name="search_provider_sponsored_description">%1$s i Lawnchair mają umowę o współdzieleniu przychodów.\n\nWyszukiwanie za pomocą %1$s wspiera rozwój Lawnchair.</string>
+    <string name="search_provider_sponsored_description">%1$s i AII Asystent mają umowę o współdzieleniu przychodów.\n\nWyszukiwanie za pomocą %1$s wspiera rozwój AII Asystent.</string>
     <string name="app_label">Aplikacja</string>
     <string name="website_label">Witryna</string>
     <string name="qsb_search_provider_app_required">Wymagana aplikacja</string>
@@ -554,7 +554,7 @@
     <string name="max_folder_columns">Maksymalna liczba kolumn w folderze</string>
     <string name="max_folder_rows">Maksymalna liczba wierszy w folderze</string>
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">Te ustawienia zostaną zignorowane, ponieważ Lawnchair nie jest ustawiony jako dostawca ekranu Ostatnich aplikacji</string>
+    <string name="quickswitch_ignored_warning">Te ustawienia zostaną zignorowane, ponieważ AII Asystent nie jest ustawiony jako dostawca ekranu Ostatnich aplikacji</string>
     <string name="quickstep_incompatible">Niekompatybilna integracja systemowa</string>
     <string name="quickstep_incompatible_description">Twoje urządzenie jest skonfigurowane, żeby używało gestów systemowych (tzw. Quickstep) dostarczonych przez %1$s, ale ta wersja %1$s nie jest zgodna z twoją wersją Androida. Aby móc dalej używać swojego urządzenia, odinstaluj aktualizacje %1$s lub zmień dostawcę gestów systemowych.</string>
     <string name="translucent_background">Prześwitujące tło</string>

--- a/lawnchair/res/values-pl/strings.xml
+++ b/lawnchair/res/values-pl/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AII Asystent
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-pt-rBR/strings.xml
+++ b/lawnchair/res/values-pt-rBR/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, Assistente de IA
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@
     <string name="time_weeks_ago">%dsem</string>
     <string name="time_months_ago">%dm</string>
     <string name="time_years_ago">%da</string>
-    <string name="managed_by_lawnchair">Gerenciado por Lawnchair</string>
+    <string name="managed_by_lawnchair">Gerenciado por Assistente de IA</string>
     <!-- When mentioning settings UI -->
     <string name="smartspace_preferences">Preferências</string>
     <string name="settings_button_text">Configurações da tela inicial</string>
@@ -69,7 +69,7 @@
     <string name="title_change_settings">Alterar configurações</string>
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout Assistente de IA
 
     -->
     <string name="others_category_label">Outros</string>
@@ -114,7 +114,7 @@
     <string name="folders_filter_duplicates">Mostrar apenas apps únicos</string>
     <string name="my_folder_label">Minha pasta</string>
     <!-- A11y description -->
-    <string name="accessibility_service_description">Para executar certas ações (como bloquear seu telefone) utilizando gestos, o Lawnchair precisar obter acesso aos recursos de acessibilidade.\n\nO Lawnchair não rastreia nenhuma ação do usuário, mesmo que o privilégio para fazer isso seja exigido para todos os serviços de acessibilidade. O Lawnchair descartará qualquer evento enviado pelo sistema.\n\nPara bloquear seu telefone, ou abrir a janela de aplicativos recentes, o Lawnchair utiliza o serviço de acessibilidade performGlobalAction.</string>
+    <string name="accessibility_service_description">Para executar certas ações (como bloquear seu telefone) utilizando gestos, o Assistente de IA precisar obter acesso aos recursos de acessibilidade.\n\nO Assistente de IA não rastreia nenhuma ação do usuário, mesmo que o privilégio para fazer isso seja exigido para todos os serviços de acessibilidade. O Assistente de IA descartará qualquer evento enviado pelo sistema.\n\nPara bloquear seu telefone, ou abrir a janela de aplicativos recentes, o Assistente de IA utiliza o serviço de acessibilidade performGlobalAction.</string>
     <string name="x_with_y_count">%1$s (%2$d)</string>
     <string name="x_by_y">%1$d x %2$d</string>
     <string name="x_and_y">%1$s &amp; %2$s</string>
@@ -143,7 +143,7 @@
     <string name="quickstep_description">Botão \"Limpar Tudo\", raio de canto</string>
     <string name="about_label">Sobre</string>
     <string name="app_info_drop_target_label">Informações do app</string>
-    <string name="debug_restart_launcher">Reiniciar o Lawnchair</string>
+    <string name="debug_restart_launcher">Reiniciar o Assistente de IA</string>
     <string name="experimental_features_label">Recursos experimentais</string>
     <!-- Experimental features -->
     <string name="font_picker_label">Customização de fonte</string>
@@ -171,7 +171,7 @@
     Notifications
 
     -->
-    <string name="set_default_launcher_tip">Para acessar atalhos e recursos adicionais, configure o Lawnchair como sua launcher padrão</string>
+    <string name="set_default_launcher_tip">Para acessar atalhos e recursos adicionais, configure o Assistente de IA como sua launcher padrão</string>
     <string name="notification_dots">Pontos de notificação</string>
     <string name="show_notification_count">Mostrar contador de notificação</string>
     <string name="notification_dots_color">Cor do ponto de notificação</string>
@@ -344,7 +344,7 @@
     <string name="event_provider_missing_notification_dots">Para usar <xliff:g example="My Provider" id="providerName">%1$s</xliff:g>, ative os pontos de notificação.</string>
     <!-- Toggle button for enabling Smartspace -->
     <string name="smartspace_widget_toggle_label">Mostrar na tela inicial</string>
-    <string name="smartspace_widget_toggle_description">O widget de Resumo pode ser adicionado manualmente à tela inicial ao colocar o widget do Lawnchair</string>
+    <string name="smartspace_widget_toggle_description">O widget de Resumo pode ser adicionado manualmente à tela inicial ao colocar o widget do Assistente de IA</string>
     <!-- List of available providers -->
     <string name="smartspace_mode_label">Provedor de Resumo</string>
     <string name="smartspace_mode_google">Google</string>
@@ -415,18 +415,18 @@
     <string name="gesture_handler_open_assistant">Abrir assistente</string>
     <string name="pick_app_for_gesture">Escolher aplicativo</string>
     <string name="dt2s_admin_hint_title">Permissões de administrador necessárias</string>
-    <string name="dt2s_admin_hint">Para usar o duplo clique para desligar a tela, defina o Lawnchair como um aplicativo de administrador do dispositivo. Toque em \"Abrir configurações\" e depois em \"Ativar o aplicativo de administrador do dispositivo.\"</string>
+    <string name="dt2s_admin_hint">Para usar o duplo clique para desligar a tela, defina o Assistente de IA como um aplicativo de administrador do dispositivo. Toque em \"Abrir configurações\" e depois em \"Ativar o aplicativo de administrador do dispositivo.\"</string>
     <string name="dt2s_admin_warning">O Toque Duplo para Desligar a tela será desativado.</string>
     <string name="d2ts_recents_a11y_hint_title">Ativar serviço de acessibilidade</string>
-    <string name="dt2s_a11y_hint">Para usar o toque duplo para desligar, ative o serviço de acessibilidade do Lawnchair. Toque em \"Abrir configurações\", selecione \"Lawnchair\" e ative \"Usar Lawnchair.\n\nLawnchair usa o método de acessibilidade `performGlobalAction` para executar essa ação. Essa é uma permissão sensível que permite monitorar outros aplicativos. No entanto, o Lawnchair não está configurado para essa funcionalidade e não recebe eventos.</string>
+    <string name="dt2s_a11y_hint">Para usar o toque duplo para desligar, ative o serviço de acessibilidade do Assistente de IA. Toque em \"Abrir configurações\", selecione \"Assistente de IA\" e ative \"Usar Assistente de IA.\n\nAssistente de IA usa o método de acessibilidade `performGlobalAction` para executar essa ação. Essa é uma permissão sensível que permite monitorar outros aplicativos. No entanto, o Assistente de IA não está configurado para essa funcionalidade e não recebe eventos.</string>
     <string name="dt2s_recents_warning_open_settings">Abrir as configurações</string>
-    <string name="recents_a11y_hint">Para usar Abrir Recentes, ative o serviço de acessibilidade do Lawnchair. Toque em \"Abrir configurações\", selecione \"Lawnchair\" e ative \"Usar o Lawnchair.\"\n\nO Lawnchair usa o método de acessibilidade `performGlobalAction` para executar essa ação. Essa é uma permissão sensível que permite monitorar outros aplicativos. No entanto, o Lawnchair não está configurado para essa funcionalidade e não irá receber eventos.</string>
+    <string name="recents_a11y_hint">Para usar Abrir Recentes, ative o serviço de acessibilidade do Assistente de IA. Toque em \"Abrir configurações\", selecione \"Assistente de IA\" e ative \"Usar o Assistente de IA.\"\n\nO Assistente de IA usa o método de acessibilidade `performGlobalAction` para executar essa ação. Essa é uma permissão sensível que permite monitorar outros aplicativos. No entanto, o Assistente de IA não está configurado para essa funcionalidade e não irá receber eventos.</string>
     <!--
 
     Bug reporting
 
     -->
-    <string name="lawnchair_bug_report">Relatório de bugs do Lawnchair</string>
+    <string name="lawnchair_bug_report">Relatório de bugs do Assistente de IA</string>
     <string name="crash_report_notif_title">%1$s crashou</string>
     <string name="action_upload_crash_report">Enviar registro de erro</string>
     <string name="action_upload_error">Falha no envio</string>
@@ -519,7 +519,7 @@
     <!-- Search providers -->
     <string name="search_provider_app_search">Pesquisa de aplicativos</string>
     <string name="search_provider_custom">Personalizar</string>
-    <string name="search_provider_sponsored_description">%1$s e Lawnchair têm um acordo de participação na receita.\n\nPesquisar usando %1$s ajuda a apoiar o Lawnchair.</string>
+    <string name="search_provider_sponsored_description">%1$s e Assistente de IA têm um acordo de participação na receita.\n\nPesquisar usando %1$s ajuda a apoiar o Assistente de IA.</string>
     <string name="app_label">Aplicativo</string>
     <string name="website_label">Site da Internet</string>
     <string name="qsb_search_provider_app_required">Aplicativo necessário</string>
@@ -552,7 +552,7 @@
     <string name="max_folder_columns">Máximo de colunas nas pastas</string>
     <string name="max_folder_rows">Máximo de linhas nas pastas</string>
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">Estas configurações serão ignoradas, já que o Lawnchair não está definido como o provedor de aplicativos recentes</string>
+    <string name="quickswitch_ignored_warning">Estas configurações serão ignoradas, já que o Assistente de IA não está definido como o provedor de aplicativos recentes</string>
     <string name="quickstep_incompatible">Integração de sistema incompatível</string>
     <string name="quickstep_incompatible_description">Seu dispositivo está configurado para ter gestos do sistema (conhecido como Quickstep) fornecidos por %1$s, mas esta versão do %1$s não é compatível com sua versão do Android. Para continuar usando o seu dispositivo, desinstale as atualizações de %1$s ou desative %1$s como provedor de gestos do sistema.</string>
     <string name="translucent_background">Fundo translúcido</string>

--- a/lawnchair/res/values-pt-rPT/strings.xml
+++ b/lawnchair/res/values-pt-rPT/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, Assistente de IA
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@
     <string name="time_weeks_ago">%dw</string>
     <string name="time_months_ago">%dmo</string>
     <string name="time_years_ago">%dy</string>
-    <string name="managed_by_lawnchair">Gerido por Lawnchair</string>
+    <string name="managed_by_lawnchair">Gerido por Assistente de IA</string>
     <!-- When mentioning settings UI -->
     <string name="smartspace_preferences">Preferências</string>
     <string name="settings_button_text">Definições do ecrã principal</string>
@@ -69,7 +69,7 @@
     <string name="title_change_settings">Alterar definições</string>
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout Assistente de IA
 
     -->
     <string name="others_category_label">Outros</string>
@@ -114,7 +114,7 @@
     <string name="folders_filter_duplicates">Only show unique apps</string>
     <string name="my_folder_label">A minha pasta</string>
     <!-- A11y description -->
-    <string name="accessibility_service_description">Para efetuar algumas ações, o Lawnchair precisa de permissões de Acessibilidade \n\nPor favor ative os serviços de acessibilidade.</string>
+    <string name="accessibility_service_description">Para efetuar algumas ações, o Assistente de IA precisa de permissões de Acessibilidade \n\nPor favor ative os serviços de acessibilidade.</string>
     <string name="x_with_y_count">%1$s (%2$d)</string>
     <string name="x_by_y">%1$d x %2$d</string>
     <string name="x_and_y">%1$s &amp; %2$s</string>
@@ -143,7 +143,7 @@
     <string name="quickstep_description">Botão limpar tudo, raio do canto</string>
     <string name="about_label">Sobre</string>
     <string name="app_info_drop_target_label">Informação das aplicações</string>
-    <string name="debug_restart_launcher">Reiniciar o Lawnchair</string>
+    <string name="debug_restart_launcher">Reiniciar o Assistente de IA</string>
     <string name="experimental_features_label">Funcionalidades experimentais</string>
     <!-- Experimental features -->
     <string name="font_picker_label">Personalização de fontes</string>
@@ -171,7 +171,7 @@
     Notifications
 
     -->
-    <string name="set_default_launcher_tip">Para aceder a atalhos e funcionalidades adicionais, define o Lawnchair como o teu launcher predefinido</string>
+    <string name="set_default_launcher_tip">Para aceder a atalhos e funcionalidades adicionais, define o Assistente de IA como o teu launcher predefinido</string>
     <string name="notification_dots">Pontos de notificação</string>
     <string name="show_notification_count">Mostrar contador de notificações</string>
     <string name="notification_dots_color">Cor do ponto de notificação</string>
@@ -345,7 +345,7 @@ Transparentes</string>
     <string name="event_provider_missing_notification_dots">Para usar <xliff:g example="My Provider" id="providerName">%1$s</xliff:g>, ative os Pontos de Notificação.</string>
     <!-- Toggle button for enabling Smartspace -->
     <string name="smartspace_widget_toggle_label">Mostrar no ecrã principal</string>
-    <string name="smartspace_widget_toggle_description">A Visualização rápida pode ser adicionada manualmente ao ecrã inicial colocando o widget Lawnchair</string>
+    <string name="smartspace_widget_toggle_description">A Visualização rápida pode ser adicionada manualmente ao ecrã inicial colocando o widget Assistente de IA</string>
     <!-- List of available providers -->
     <string name="smartspace_mode_label">Fornecedor de Visualização rápida</string>
     <string name="smartspace_mode_google">Google</string>
@@ -416,18 +416,18 @@ Transparentes</string>
     <string name="gesture_handler_open_assistant">Abrir assistente</string>
     <string name="pick_app_for_gesture">Escolher aplicação</string>
     <string name="dt2s_admin_hint_title">Permissões de administrador necessárias</string>
-    <string name="dt2s_admin_hint">Para usar o Toque Duplo para Adormecer, defina o Lawnchair como uma aplicação de administração do dispositivo. Toque em \"Abrir definições\", depois em \"Ativar esta aplicação de administração do dispositivo.\"</string>
+    <string name="dt2s_admin_hint">Para usar o Toque Duplo para Adormecer, defina o Assistente de IA como uma aplicação de administração do dispositivo. Toque em \"Abrir definições\", depois em \"Ativar esta aplicação de administração do dispositivo.\"</string>
     <string name="dt2s_admin_warning">O Duplo Toque para Dormir será desativado.</string>
     <string name="d2ts_recents_a11y_hint_title">Ativar o serviço de acessibilidade</string>
-    <string name="dt2s_a11y_hint">Para usar o Toque Duplo para Dormir, ativa o serviço de acessibilidade do Lawnchair. Toca em \"Abrir definições\", seleciona \"Lawnchair\" e ativa \"Usar Lawnchair\".\n\nO Lawnchair utiliza o método `performGlobalAction` da Acessibilidade para realizar esta ação. Esta é uma permissão sensível que permite monitorizar outras aplicações. No entanto, o Lawnchair não está configurado para essa funcionalidade e não recebe eventos.</string>
+    <string name="dt2s_a11y_hint">Para usar o Toque Duplo para Dormir, ativa o serviço de acessibilidade do Assistente de IA. Toca em \"Abrir definições\", seleciona \"Assistente de IA\" e ativa \"Usar Assistente de IA\".\n\nO Assistente de IA utiliza o método `performGlobalAction` da Acessibilidade para realizar esta ação. Esta é uma permissão sensível que permite monitorizar outras aplicações. No entanto, o Assistente de IA não está configurado para essa funcionalidade e não recebe eventos.</string>
     <string name="dt2s_recents_warning_open_settings">Abrir definições</string>
-    <string name="recents_a11y_hint">To use Open Recents screen, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="recents_a11y_hint">To use Open Recents screen, turn on the Assistente de IA accessibility service. Tap \"Open settings\", select \"Assistente de IA\" and turn on \"Use Assistente de IA.\"\n\nAssistente de IA uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Assistente de IA is not configured for that functionality and receives no events.</string>
     <!--
 
     Bug reporting
 
     -->
-    <string name="lawnchair_bug_report">Relatório de erro do Lawnchair</string>
+    <string name="lawnchair_bug_report">Relatório de erro do Assistente de IA</string>
     <string name="crash_report_notif_title">%1$s parou de funcionar</string>
     <string name="action_upload_crash_report">Carregar registo de falhas</string>
     <string name="action_upload_error">Falha no envio</string>
@@ -520,7 +520,7 @@ Transparentes</string>
     <!-- Search providers -->
     <string name="search_provider_app_search">Pesquisa de aplicações</string>
     <string name="search_provider_custom">Personalizado</string>
-    <string name="search_provider_sponsored_description">%1$s e o Lawnchair têm um acordo de partilha de receitas.\n\nPesquisar com o %1$s ajuda a apoiar o Lawnchair.</string>
+    <string name="search_provider_sponsored_description">%1$s e o Assistente de IA têm um acordo de partilha de receitas.\n\nPesquisar com o %1$s ajuda a apoiar o Assistente de IA.</string>
     <string name="app_label">Aplicação</string>
     <string name="website_label">Website</string>
     <string name="qsb_search_provider_app_required">Aplicação necessária</string>
@@ -553,7 +553,7 @@ Transparentes</string>
     <string name="max_folder_columns">Número máximo de colunas na pasta</string>
     <string name="max_folder_rows">Número máximo de linhas na pasta</string>
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">These settings will be ignored as Lawnchair isn\'t set as the Recents screen provider</string>
+    <string name="quickswitch_ignored_warning">These settings will be ignored as Assistente de IA isn\'t set as the Recents screen provider</string>
     <string name="quickstep_incompatible">Integração do sistema incompatível</string>
     <string name="quickstep_incompatible_description">O seu dispositivo está configurado para ter gestos do sistema (conhecidos como Quickstep) fornecidos por %1$s, mas esta versão de %1$s não é compatível com a versão do seu Android. Para continuar a usar o seu dispositivo, desinstale as atualizações de %1$s ou desative %1$s como fornecedor de gestos do sistema.</string>
     <string name="translucent_background">Fundo translúcido</string>

--- a/lawnchair/res/values-pt/strings.xml
+++ b/lawnchair/res/values-pt/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, Assistente de IA
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-ro-rRO/strings.xml
+++ b/lawnchair/res/values-ro-rRO/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, Asistent AI
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@
     <string name="time_weeks_ago">%dw</string>
     <string name="time_months_ago">%dmo</string>
     <string name="time_years_ago">%dy</string>
-    <string name="managed_by_lawnchair">Administrat de Lawnchair</string>
+    <string name="managed_by_lawnchair">Administrat de Asistent AI</string>
     <!-- When mentioning settings UI -->
     <string name="smartspace_preferences">Preferințe</string>
     <string name="settings_button_text">Home settings</string>
@@ -69,7 +69,7 @@
     <string name="title_change_settings">Change settings</string>
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout Asistent AI
 
     -->
     <string name="others_category_label">Others</string>
@@ -114,7 +114,7 @@
     <string name="folders_filter_duplicates">Only show unique apps</string>
     <string name="my_folder_label">My folder</string>
     <!-- A11y description -->
-    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, Lawnchair uses the performGlobalAction Accessibility service.</string>
+    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, Asistent AI requires accessibility access.\n\nAsistent AI doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Asistent AI discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, Asistent AI uses the performGlobalAction Accessibility service.</string>
     <string name="x_with_y_count">%1$s (%2$d)</string>
     <string name="x_by_y">%1$d x %2$d</string>
     <string name="x_and_y">%1$s &amp; %2$s</string>
@@ -143,7 +143,7 @@
     <string name="quickstep_description">Clear All button, corner radius</string>
     <string name="about_label">Despre</string>
     <string name="app_info_drop_target_label">App info</string>
-    <string name="debug_restart_launcher">Repornește Lawnchair</string>
+    <string name="debug_restart_launcher">Repornește Asistent AI</string>
     <string name="experimental_features_label">Experimental features</string>
     <!-- Experimental features -->
     <string name="font_picker_label">Font customization</string>
@@ -171,7 +171,7 @@
     Notifications
 
     -->
-    <string name="set_default_launcher_tip">To access shortcuts and additional features, set Lawnchair as your default launcher</string>
+    <string name="set_default_launcher_tip">To access shortcuts and additional features, set Asistent AI as your default launcher</string>
     <string name="notification_dots">Notification dots</string>
     <string name="show_notification_count">Show notification counter</string>
     <string name="notification_dots_color">Notification dot color</string>
@@ -344,7 +344,7 @@
     <string name="event_provider_missing_notification_dots">To use <xliff:g example="My Provider" id="providerName">%1$s</xliff:g>, turn on Notification Dots.</string>
     <!-- Toggle button for enabling Smartspace -->
     <string name="smartspace_widget_toggle_label">Show on home screen</string>
-    <string name="smartspace_widget_toggle_description">At a Glance can be manually added to the home screen by placing the Lawnchair widget</string>
+    <string name="smartspace_widget_toggle_description">At a Glance can be manually added to the home screen by placing the Asistent AI widget</string>
     <!-- List of available providers -->
     <string name="smartspace_mode_label">At a Glance provider</string>
     <string name="smartspace_mode_google">Google</string>
@@ -415,18 +415,18 @@
     <string name="gesture_handler_open_assistant">Open assistant</string>
     <string name="pick_app_for_gesture">Pick app</string>
     <string name="dt2s_admin_hint_title">Admin permissions required</string>
-    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set Lawnchair as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
+    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set Asistent AI as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
     <string name="dt2s_admin_warning">Dublă-atingerea pentru oprirea ecranului va fi dezactivată.</string>
     <string name="d2ts_recents_a11y_hint_title">Turn on accessibility service</string>
-    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the Asistent AI accessibility service. Tap \"Open settings\", select \"Asistent AI\" and turn on \"Use Asistent AI.\"\n\nAsistent AI uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Asistent AI is not configured for that functionality and receives no events.</string>
     <string name="dt2s_recents_warning_open_settings">Open settings</string>
-    <string name="recents_a11y_hint">To use Open Recents screen, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="recents_a11y_hint">To use Open Recents screen, turn on the Asistent AI accessibility service. Tap \"Open settings\", select \"Asistent AI\" and turn on \"Use Asistent AI.\"\n\nAsistent AI uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Asistent AI is not configured for that functionality and receives no events.</string>
     <!--
 
     Bug reporting
 
     -->
-    <string name="lawnchair_bug_report">Lawnchair bug report</string>
+    <string name="lawnchair_bug_report">Asistent AI bug report</string>
     <string name="crash_report_notif_title">%1$s crashed</string>
     <string name="action_upload_crash_report">Upload crash log</string>
     <string name="action_upload_error">Încărcare nereuşită</string>
@@ -519,7 +519,7 @@
     <!-- Search providers -->
     <string name="search_provider_app_search">App search</string>
     <string name="search_provider_custom">Personalizat</string>
-    <string name="search_provider_sponsored_description">%1$s and Lawnchair have a revenue share agreement.\n\nSearching with %1$s helps support Lawnchair.</string>
+    <string name="search_provider_sponsored_description">%1$s and Asistent AI have a revenue share agreement.\n\nSearching with %1$s helps support Asistent AI.</string>
     <string name="app_label">Aplicație</string>
     <string name="website_label">Site web</string>
     <string name="qsb_search_provider_app_required">App required</string>
@@ -553,7 +553,7 @@
     <string name="max_folder_columns">Maximum folder columns</string>
     <string name="max_folder_rows">Maximum folder rows</string>
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">These settings will be ignored as Lawnchair isn\'t set as the Recents screen provider</string>
+    <string name="quickswitch_ignored_warning">These settings will be ignored as Asistent AI isn\'t set as the Recents screen provider</string>
     <string name="quickstep_incompatible">Incompatible system integration</string>
     <string name="quickstep_incompatible_description">Your device is configured to have system gestures (known as Quickstep) provided by %1$s, but this version of %1$s isn\'t compatible with your Android version. To continue using your device, please uninstall %1$s updates or disable %1$s as a system gesture provider.</string>
     <string name="translucent_background">Translucent background</string>

--- a/lawnchair/res/values-ro/strings.xml
+++ b/lawnchair/res/values-ro/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, Asistent AI
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-ru-rRU/strings.xml
+++ b/lawnchair/res/values-ru-rRU/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, ИИ помощник
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@
     <string name="time_weeks_ago">%dw</string>
     <string name="time_months_ago">%dmo</string>
     <string name="time_years_ago">%dy</string>
-    <string name="managed_by_lawnchair">Управляется Lawnchair</string>
+    <string name="managed_by_lawnchair">Управляется ИИ помощник</string>
     <!-- When mentioning settings UI -->
     <string name="smartspace_preferences">Настройки</string>
     <string name="settings_button_text">Настройки лаунчера</string>
@@ -69,7 +69,7 @@
     <string name="title_change_settings">Изменить настройки</string>
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout ИИ помощник
 
     -->
     <string name="others_category_label">Прочее</string>
@@ -114,7 +114,7 @@
     <string name="folders_filter_duplicates">Показывать только неповторяющиеся приложения</string>
     <string name="my_folder_label">Моя папка</string>
     <!-- A11y description -->
-    <string name="accessibility_service_description">Для выполнения определённых действий (например, блокировки телефона) с помощью жестов, Lawnchair требуется доступ к спец. возможностям.\n\nLawnchair не отслеживает действий пользователя, хотя это требуется для всех служб спец. возможностей. Lawnchair не учитывает любые системные события.\n\nЧтобы заблокировать телефон или открыть Экран недавних приложений, Lawnchair использует службу спец. возможностей PerformGlobalAction.</string>
+    <string name="accessibility_service_description">Для выполнения определённых действий (например, блокировки телефона) с помощью жестов, ИИ помощник требуется доступ к спец. возможностям.\n\nИИ помощник не отслеживает действий пользователя, хотя это требуется для всех служб спец. возможностей. ИИ помощник не учитывает любые системные события.\n\nЧтобы заблокировать телефон или открыть Экран недавних приложений, ИИ помощник использует службу спец. возможностей PerformGlobalAction.</string>
     <string name="x_with_y_count">%1$s (%2$d)</string>
     <string name="x_by_y">%1$d × %2$d</string>
     <string name="x_and_y">%1$s и %2$s</string>
@@ -143,7 +143,7 @@
     <string name="quickstep_description">Кнопка \"Очистить всё\", радиус углов</string>
     <string name="about_label">О программе</string>
     <string name="app_info_drop_target_label">О приложении</string>
-    <string name="debug_restart_launcher">Перезапустить Lawnchair</string>
+    <string name="debug_restart_launcher">Перезапустить ИИ помощник</string>
     <string name="experimental_features_label">Эксперимент. функции</string>
     <!-- Experimental features -->
     <string name="font_picker_label">Настройки шрифта</string>
@@ -171,7 +171,7 @@
     Notifications
 
     -->
-    <string name="set_default_launcher_tip">Для доступа к ярлыкам и доп. функциям, установите Lawnchair в качестве лаунчера по умолчанию</string>
+    <string name="set_default_launcher_tip">Для доступа к ярлыкам и доп. функциям, установите ИИ помощник в качестве лаунчера по умолчанию</string>
     <string name="notification_dots">Включить Точки уведомлений</string>
     <string name="show_notification_count">Отображать счётчик уведомлений</string>
     <string name="notification_dots_color">Цвет Точек уведомлений</string>
@@ -344,7 +344,7 @@
     <string name="event_provider_missing_notification_dots">Чтобы использовать провайдер событий <xliff:g example="My Provider" id="providerName">%1$s</xliff:g>, включите Точки уведомлений.</string>
     <!-- Toggle button for enabling Smartspace -->
     <string name="smartspace_widget_toggle_label">Показывать на глав. экране</string>
-    <string name="smartspace_widget_toggle_description">Данные виджета \"Самое главное\" можно добавить на глав. экран вручную с помощью виджета \"Lawnchair\"</string>
+    <string name="smartspace_widget_toggle_description">Данные виджета \"Самое главное\" можно добавить на глав. экран вручную с помощью виджета \"ИИ помощник\"</string>
     <!-- List of available providers -->
     <string name="smartspace_mode_label">Провайдер виджета \"Самое главное\"</string>
     <string name="smartspace_mode_google">Google</string>
@@ -415,18 +415,18 @@
     <string name="gesture_handler_open_assistant">Открыть приложение-ассистент</string>
     <string name="pick_app_for_gesture">Выбрать приложение</string>
     <string name="dt2s_admin_hint_title">Необходимы права администратора</string>
-    <string name="dt2s_admin_hint">Чтобы использовать Спящий режим по двойному нажатию, назначьте Lawnchair администратором устройства. Для этого: откройте Настройки, затем нажмите на \"Активировать приложение администратора устройства.\"</string>
+    <string name="dt2s_admin_hint">Чтобы использовать Спящий режим по двойному нажатию, назначьте ИИ помощник администратором устройства. Для этого: откройте Настройки, затем нажмите на \"Активировать приложение администратора устройства.\"</string>
     <string name="dt2s_admin_warning">Двойное нажатие для Спящего режима будет отключено.</string>
     <string name="d2ts_recents_a11y_hint_title">Включить службу спец. возможностей</string>
-    <string name="dt2s_a11y_hint">Чтобы использовать двойное нажатие для Спящего режима, включите службу спец. возможностей Lawnchair. Нажмите «Открыть настройки», выберите «Lawnchair» и включите переключатель «Использовать Lawnchair». \n\nLawnchair использует метод спец. возможностей «performGlobalAction» для выполнения этого действия. Необходима осторожность, т.к. это разрешение позволяет отслеживать другие приложения. Тем не менее, Lawnchair не настроен на эту функциональность и не получает никаких событий.</string>
+    <string name="dt2s_a11y_hint">Чтобы использовать двойное нажатие для Спящего режима, включите службу спец. возможностей ИИ помощник. Нажмите «Открыть настройки», выберите «ИИ помощник» и включите переключатель «Использовать ИИ помощник». \n\nИИ помощник использует метод спец. возможностей «performGlobalAction» для выполнения этого действия. Необходима осторожность, т.к. это разрешение позволяет отслеживать другие приложения. Тем не менее, ИИ помощник не настроен на эту функциональность и не получает никаких событий.</string>
     <string name="dt2s_recents_warning_open_settings">Открыть настройки</string>
-    <string name="recents_a11y_hint">Для открытия Экрана недавних приложений, включите службу спец. возможностей Lawnchair. Нажмите «Открыть настройки», выберите «Lawnchair» и включите переключатель «Использовать Lawnchair». \n\nLawnchair использует метод службы спец. возможностей «performGlobalAction» для выполнения этого действия. Необходима осторожность, т.к. это разрешение позволяет отслеживать другие приложения. Тем не менее, Lawnchair не настроен на эту функциональность и не получает никаких событий.</string>
+    <string name="recents_a11y_hint">Для открытия Экрана недавних приложений, включите службу спец. возможностей ИИ помощник. Нажмите «Открыть настройки», выберите «ИИ помощник» и включите переключатель «Использовать ИИ помощник». \n\nИИ помощник использует метод службы спец. возможностей «performGlobalAction» для выполнения этого действия. Необходима осторожность, т.к. это разрешение позволяет отслеживать другие приложения. Тем не менее, ИИ помощник не настроен на эту функциональность и не получает никаких событий.</string>
     <!--
 
     Bug reporting
 
     -->
-    <string name="lawnchair_bug_report">Отчет об ошибках Lawnchair</string>
+    <string name="lawnchair_bug_report">Отчет об ошибках ИИ помощник</string>
     <string name="crash_report_notif_title">%1$s - произошел сбой</string>
     <string name="action_upload_crash_report">Отправить лог ошибки</string>
     <string name="action_upload_error">Отправка не удалась</string>
@@ -519,7 +519,7 @@
     <!-- Search providers -->
     <string name="search_provider_app_search">Поиск по приложениям</string>
     <string name="search_provider_custom">Польз. настройки</string>
-    <string name="search_provider_sponsored_description">%1$s и Lawnchair имеют соглашение о разделе доходов.\n\nПоиск с помощью %1$s помогает поддерживать Lawnchair.</string>
+    <string name="search_provider_sponsored_description">%1$s и ИИ помощник имеют соглашение о разделе доходов.\n\nПоиск с помощью %1$s помогает поддерживать ИИ помощник.</string>
     <string name="app_label">Приложение</string>
     <string name="website_label">Веб-сайт</string>
     <string name="qsb_search_provider_app_required">Требуется приложение</string>
@@ -554,7 +554,7 @@
     <string name="max_folder_columns">Макс. кол-во столбцов в папке</string>
     <string name="max_folder_rows">Макс. кол-во строк в папке</string>
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">Эти настройки будут проигнорированы, так как Lawnchair не установлен в качестве провайдера Экрана недавних приложений</string>
+    <string name="quickswitch_ignored_warning">Эти настройки будут проигнорированы, так как ИИ помощник не установлен в качестве провайдера Экрана недавних приложений</string>
     <string name="quickstep_incompatible">Несовместимая системная интеграция</string>
     <string name="quickstep_incompatible_description">Ваше устройство настроено на использование системных жестов (известных как Quickstep), предоставляемых %1$s, но эта версия %1$s не совместима с вашей версией Android. Чтобы продолжить использование вашего устройства, удалите обновления %1$s или отключите %1$s как поставщика системных жестов.</string>
     <string name="translucent_background">Полупрозрачный фон</string>

--- a/lawnchair/res/values-ru/strings.xml
+++ b/lawnchair/res/values-ru/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, ИИ помощник
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-si/strings.xml
+++ b/lawnchair/res/values-si/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI සහායක
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-sk-rSK/strings.xml
+++ b/lawnchair/res/values-sk-rSK/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, Asistent
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@
     <string name="time_weeks_ago">%dw</string>
     <string name="time_months_ago">%dmo</string>
     <string name="time_years_ago">%dy</string>
-    <string name="managed_by_lawnchair">Spravované Lawnchair</string>
+    <string name="managed_by_lawnchair">Spravované Asistent</string>
     <!-- When mentioning settings UI -->
     <string name="smartspace_preferences">Predvoľby</string>
     <string name="settings_button_text">Nastavenia domovskej obrazovky</string>
@@ -69,7 +69,7 @@
     <string name="title_change_settings">Zmeniť nastavenia</string>
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout Asistent
 
     -->
     <string name="others_category_label">Others</string>
@@ -114,7 +114,7 @@
     <string name="folders_filter_duplicates">Only show unique apps</string>
     <string name="my_folder_label">My folder</string>
     <!-- A11y description -->
-    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, Lawnchair uses the performGlobalAction Accessibility service.</string>
+    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, Asistent requires accessibility access.\n\nAsistent doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Asistent discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, Asistent uses the performGlobalAction Accessibility service.</string>
     <string name="x_with_y_count">%1$s (%2$d)</string>
     <string name="x_by_y">%1$d × %2$d</string>
     <string name="x_and_y">%1$s a %2$s</string>
@@ -143,7 +143,7 @@
     <string name="quickstep_description">Vymazať tlačidlo všetko, Polomery rohov</string>
     <string name="about_label">O aplikácii</string>
     <string name="app_info_drop_target_label">Informácie o aplikácii</string>
-    <string name="debug_restart_launcher">Reštartovať Lawnchair</string>
+    <string name="debug_restart_launcher">Reštartovať Asistent</string>
     <string name="experimental_features_label">Experimentálne funkcie</string>
     <!-- Experimental features -->
     <string name="font_picker_label">Prispôsobenie písma</string>
@@ -171,7 +171,7 @@
     Notifications
 
     -->
-    <string name="set_default_launcher_tip">Pre prístup k skratkám a ďalších funkcii nastavte Lawnchair ako predvolebný spúšťač</string>
+    <string name="set_default_launcher_tip">Pre prístup k skratkám a ďalších funkcii nastavte Asistent ako predvolebný spúšťač</string>
     <string name="notification_dots">Bodky upozornení</string>
     <string name="show_notification_count">Zobraziť počet oznámení</string>
     <string name="notification_dots_color">Farby bodky upozornenia</string>
@@ -344,7 +344,7 @@
     <string name="event_provider_missing_notification_dots">Ak chcete použiť &lt;xliff:g example=„My Provider“ id=„providerName“&gt;%1$s&lt;/xliff:g&gt;, zapnite funkciu Oznamovaciu Bodku.</string>
     <!-- Toggle button for enabling Smartspace -->
     <string name="smartspace_widget_toggle_label">Ukázať na domovskej obrazovke</string>
-    <string name="smartspace_widget_toggle_description">Prehľad udalostí môže byť pridaný ručne prostredníctvom widgetu „Lawnchair“.</string>
+    <string name="smartspace_widget_toggle_description">Prehľad udalostí môže byť pridaný ručne prostredníctvom widgetu „Asistent“.</string>
     <!-- List of available providers -->
     <string name="smartspace_mode_label">Poskytovateľ Prehľadu udalostí</string>
     <string name="smartspace_mode_google">Google</string>
@@ -415,18 +415,18 @@
     <string name="gesture_handler_open_assistant">Open assistant</string>
     <string name="pick_app_for_gesture">Vybrať aplikáciu</string>
     <string name="dt2s_admin_hint_title">Nutné povolenia správcu</string>
-    <string name="dt2s_admin_hint">Pre používanie dvojitého kliknutia pre uspanie, nastavte Lawnchair ako správcu aplikácie. Kliknite na Nastavenia a potom na \"Aktivujte túto aplikáciu ako správca.\"</string>
+    <string name="dt2s_admin_hint">Pre používanie dvojitého kliknutia pre uspanie, nastavte Asistent ako správcu aplikácie. Kliknite na Nastavenia a potom na \"Aktivujte túto aplikáciu ako správca.\"</string>
     <string name="dt2s_admin_warning">Dvojité kliknutie pre uspanie bude vypnuté.</string>
     <string name="d2ts_recents_a11y_hint_title">Zapnúť službu prístupnosti</string>
-    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the Asistent accessibility service. Tap \"Open settings\", select \"Asistent\" and turn on \"Use Asistent.\"\n\nAsistent uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Asistent is not configured for that functionality and receives no events.</string>
     <string name="dt2s_recents_warning_open_settings">Otvoriť nastavenia</string>
-    <string name="recents_a11y_hint">To use Open Recents screen, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="recents_a11y_hint">To use Open Recents screen, turn on the Asistent accessibility service. Tap \"Open settings\", select \"Asistent\" and turn on \"Use Asistent.\"\n\nAsistent uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Asistent is not configured for that functionality and receives no events.</string>
     <!--
 
     Bug reporting
 
     -->
-    <string name="lawnchair_bug_report">Správa o chybe v Lawnchair-i</string>
+    <string name="lawnchair_bug_report">Správa o chybe v Asistent-i</string>
     <string name="crash_report_notif_title">%1$s Spadol</string>
     <string name="action_upload_crash_report">Nahrať výpis o páde</string>
     <string name="action_upload_error">Nahrávanie zlyhalo</string>
@@ -519,7 +519,7 @@
     <!-- Search providers -->
     <string name="search_provider_app_search">Vyhľadávanie aplikácií</string>
     <string name="search_provider_custom">Vlastné</string>
-    <string name="search_provider_sponsored_description">%1$s A Lawnchair má zmluvu o zdieľanie prijmú.\n\nVyhladavanie pomocou %1$s pomáha podporiť Lawnchair.</string>
+    <string name="search_provider_sponsored_description">%1$s A Asistent má zmluvu o zdieľanie prijmú.\n\nVyhladavanie pomocou %1$s pomáha podporiť Asistent.</string>
     <string name="app_label">Aplikácia</string>
     <string name="website_label">Webová stránka</string>
     <string name="qsb_search_provider_app_required">Vyžaduje sa aplikácia</string>
@@ -554,7 +554,7 @@
     <string name="max_folder_columns">Max. počet stĺpcov v priečinku</string>
     <string name="max_folder_rows">Max. počet stĺpcov v priečinku</string>
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">These settings will be ignored as Lawnchair isn\'t set as the Recents screen provider</string>
+    <string name="quickswitch_ignored_warning">These settings will be ignored as Asistent isn\'t set as the Recents screen provider</string>
     <string name="quickstep_incompatible">Nekompatibilná integrácia systému</string>
     <string name="quickstep_incompatible_description">Vaše zariadenie je nakonfigurované na systémové gestá (známe ako Quickstep), ktoré poskytuje %1$s, ale táto verzia %1$s nie je kompatibilná s vašou verziou systému Android. Ak chcete pokračovať v používaní svojho zariadenia, odinštalujte aktualizácie %1$s alebo vypnite %1$s ako poskytovateľa systémových gest.</string>
     <string name="translucent_background">Priesvitné pozadie</string>

--- a/lawnchair/res/values-sk/strings.xml
+++ b/lawnchair/res/values-sk/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, Asistent
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-sl-rSI/strings.xml
+++ b/lawnchair/res/values-sl-rSI/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI asistent
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@
     <string name="time_weeks_ago">%dw</string>
     <string name="time_months_ago">%dmo</string>
     <string name="time_years_ago">%dy</string>
-    <string name="managed_by_lawnchair">Managed by Lawnchair</string>
+    <string name="managed_by_lawnchair">Managed by AI asistent</string>
     <!-- When mentioning settings UI -->
     <string name="smartspace_preferences">Preference</string>
     <string name="settings_button_text">Home settings</string>
@@ -69,7 +69,7 @@
     <string name="title_change_settings">Change settings</string>
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout AI asistent
 
     -->
     <string name="others_category_label">Others</string>
@@ -114,7 +114,7 @@
     <string name="folders_filter_duplicates">Only show unique apps</string>
     <string name="my_folder_label">My folder</string>
     <!-- A11y description -->
-    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, Lawnchair uses the performGlobalAction Accessibility service.</string>
+    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, AI asistent requires accessibility access.\n\nAI asistent doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. AI asistent discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, AI asistent uses the performGlobalAction Accessibility service.</string>
     <string name="x_with_y_count">%1$s (%2$d)</string>
     <string name="x_by_y">%1$d x %2$d</string>
     <string name="x_and_y">%1$s &amp; %2$s</string>
@@ -143,7 +143,7 @@
     <string name="quickstep_description">Clear All button, corner radius</string>
     <string name="about_label">O tem</string>
     <string name="app_info_drop_target_label">App info</string>
-    <string name="debug_restart_launcher">Resetiraj Lawnchair</string>
+    <string name="debug_restart_launcher">Resetiraj AI asistent</string>
     <string name="experimental_features_label">Experimental features</string>
     <!-- Experimental features -->
     <string name="font_picker_label">Font customization</string>
@@ -171,7 +171,7 @@
     Notifications
 
     -->
-    <string name="set_default_launcher_tip">To access shortcuts and additional features, set Lawnchair as your default launcher</string>
+    <string name="set_default_launcher_tip">To access shortcuts and additional features, set AI asistent as your default launcher</string>
     <string name="notification_dots">Notification dots</string>
     <string name="show_notification_count">Show notification counter</string>
     <string name="notification_dots_color">Notification dot color</string>
@@ -344,7 +344,7 @@
     <string name="event_provider_missing_notification_dots">To use <xliff:g example="My Provider" id="providerName">%1$s</xliff:g>, turn on Notification Dots.</string>
     <!-- Toggle button for enabling Smartspace -->
     <string name="smartspace_widget_toggle_label">Show on home screen</string>
-    <string name="smartspace_widget_toggle_description">At a Glance can be manually added to the home screen by placing the Lawnchair widget</string>
+    <string name="smartspace_widget_toggle_description">At a Glance can be manually added to the home screen by placing the AI asistent widget</string>
     <!-- List of available providers -->
     <string name="smartspace_mode_label">At a Glance provider</string>
     <string name="smartspace_mode_google">Google</string>
@@ -415,18 +415,18 @@
     <string name="gesture_handler_open_assistant">Open assistant</string>
     <string name="pick_app_for_gesture">Pick app</string>
     <string name="dt2s_admin_hint_title">Admin permissions required</string>
-    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set Lawnchair as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
+    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set AI asistent as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
     <string name="dt2s_admin_warning">Double-Tap za spanje bo izklopljen.</string>
     <string name="d2ts_recents_a11y_hint_title">Turn on accessibility service</string>
-    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the AI asistent accessibility service. Tap \"Open settings\", select \"AI asistent\" and turn on \"Use AI asistent.\"\n\nAI asistent uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, AI asistent is not configured for that functionality and receives no events.</string>
     <string name="dt2s_recents_warning_open_settings">Open settings</string>
-    <string name="recents_a11y_hint">To use Open Recents screen, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="recents_a11y_hint">To use Open Recents screen, turn on the AI asistent accessibility service. Tap \"Open settings\", select \"AI asistent\" and turn on \"Use AI asistent.\"\n\nAI asistent uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, AI asistent is not configured for that functionality and receives no events.</string>
     <!--
 
     Bug reporting
 
     -->
-    <string name="lawnchair_bug_report">Lawnchair bug report</string>
+    <string name="lawnchair_bug_report">AI asistent bug report</string>
     <string name="crash_report_notif_title">%1$s crashed</string>
     <string name="action_upload_crash_report">Upload crash log</string>
     <string name="action_upload_error">Prenos neuspešen</string>
@@ -519,7 +519,7 @@
     <!-- Search providers -->
     <string name="search_provider_app_search">App search</string>
     <string name="search_provider_custom">Po meri</string>
-    <string name="search_provider_sponsored_description">%1$s and Lawnchair have a revenue share agreement.\n\nSearching with %1$s helps support Lawnchair.</string>
+    <string name="search_provider_sponsored_description">%1$s and AI asistent have a revenue share agreement.\n\nSearching with %1$s helps support AI asistent.</string>
     <string name="app_label">App</string>
     <string name="website_label">Website</string>
     <string name="qsb_search_provider_app_required">App required</string>
@@ -554,7 +554,7 @@
     <string name="max_folder_columns">Maximum folder columns</string>
     <string name="max_folder_rows">Maximum folder rows</string>
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">These settings will be ignored as Lawnchair isn\'t set as the Recents screen provider</string>
+    <string name="quickswitch_ignored_warning">These settings will be ignored as AI asistent isn\'t set as the Recents screen provider</string>
     <string name="quickstep_incompatible">Incompatible system integration</string>
     <string name="quickstep_incompatible_description">Your device is configured to have system gestures (known as Quickstep) provided by %1$s, but this version of %1$s isn\'t compatible with your Android version. To continue using your device, please uninstall %1$s updates or disable %1$s as a system gesture provider.</string>
     <string name="translucent_background">Translucent background</string>

--- a/lawnchair/res/values-sl/strings.xml
+++ b/lawnchair/res/values-sl/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI asistent
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-sq-rAL/strings.xml
+++ b/lawnchair/res/values-sq-rAL/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, Asistent i AI
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@
     <string name="time_weeks_ago">%dw</string>
     <string name="time_months_ago">%dmo</string>
     <string name="time_years_ago">%dy</string>
-    <string name="managed_by_lawnchair">Menaxhuar nga Lawnchair</string>
+    <string name="managed_by_lawnchair">Menaxhuar nga Asistent i AI</string>
     <!-- When mentioning settings UI -->
     <string name="smartspace_preferences">Preferencat</string>
     <string name="settings_button_text">Konfigurimet e shtëpisë</string>
@@ -69,7 +69,7 @@
     <string name="title_change_settings">Ndrysho konfigurimet</string>
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout Asistent i AI
 
     -->
     <string name="others_category_label">Others</string>
@@ -114,7 +114,7 @@
     <string name="folders_filter_duplicates">Only show unique apps</string>
     <string name="my_folder_label">My folder</string>
     <!-- A11y description -->
-    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, Lawnchair uses the performGlobalAction Accessibility service.</string>
+    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, Asistent i AI requires accessibility access.\n\nAsistent i AI doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Asistent i AI discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, Asistent i AI uses the performGlobalAction Accessibility service.</string>
     <string name="x_with_y_count">%1$s (%2$d)</string>
     <string name="x_by_y">%1$d × %2$d</string>
     <string name="x_and_y">%1$s&amp;%2$s</string>
@@ -143,7 +143,7 @@
     <string name="quickstep_description">Butoni për të fshirë gjithqka, rrezja e këndeve</string>
     <string name="about_label">Rreth</string>
     <string name="app_info_drop_target_label">Informacion për aplikacion</string>
-    <string name="debug_restart_launcher">Rifillo Lawnchair</string>
+    <string name="debug_restart_launcher">Rifillo Asistent i AI</string>
     <string name="experimental_features_label">Veçoritë eksperimentale</string>
     <!-- Experimental features -->
     <string name="font_picker_label">Personalizo shkronjat</string>
@@ -171,7 +171,7 @@
     Notifications
 
     -->
-    <string name="set_default_launcher_tip">To access shortcuts and additional features, set Lawnchair as your default launcher</string>
+    <string name="set_default_launcher_tip">To access shortcuts and additional features, set Asistent i AI as your default launcher</string>
     <string name="notification_dots">Notification dots</string>
     <string name="show_notification_count">Show notification counter</string>
     <string name="notification_dots_color">Notification dot color</string>
@@ -344,7 +344,7 @@
     <string name="event_provider_missing_notification_dots">To use <xliff:g example="My Provider" id="providerName">%1$s</xliff:g>, turn on Notification Dots.</string>
     <!-- Toggle button for enabling Smartspace -->
     <string name="smartspace_widget_toggle_label">Show on home screen</string>
-    <string name="smartspace_widget_toggle_description">At a Glance can be manually added to the home screen by placing the Lawnchair widget</string>
+    <string name="smartspace_widget_toggle_description">At a Glance can be manually added to the home screen by placing the Asistent i AI widget</string>
     <!-- List of available providers -->
     <string name="smartspace_mode_label">At a Glance provider</string>
     <string name="smartspace_mode_google">Google</string>
@@ -415,18 +415,18 @@
     <string name="gesture_handler_open_assistant">Open assistant</string>
     <string name="pick_app_for_gesture">Pick app</string>
     <string name="dt2s_admin_hint_title">Admin permissions required</string>
-    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set Lawnchair as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
+    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set Asistent i AI as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
     <string name="dt2s_admin_warning">Kliko Dy Herë per te Kyqur do të çaktivizohet.</string>
     <string name="d2ts_recents_a11y_hint_title">Turn on accessibility service</string>
-    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the Asistent i AI accessibility service. Tap \"Open settings\", select \"Asistent i AI\" and turn on \"Use Asistent i AI.\"\n\nAsistent i AI uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Asistent i AI is not configured for that functionality and receives no events.</string>
     <string name="dt2s_recents_warning_open_settings">Open settings</string>
-    <string name="recents_a11y_hint">To use Open Recents screen, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="recents_a11y_hint">To use Open Recents screen, turn on the Asistent i AI accessibility service. Tap \"Open settings\", select \"Asistent i AI\" and turn on \"Use Asistent i AI.\"\n\nAsistent i AI uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Asistent i AI is not configured for that functionality and receives no events.</string>
     <!--
 
     Bug reporting
 
     -->
-    <string name="lawnchair_bug_report">Lawnchair bug report</string>
+    <string name="lawnchair_bug_report">Asistent i AI bug report</string>
     <string name="crash_report_notif_title">%1$s crashed</string>
     <string name="action_upload_crash_report">Upload crash log</string>
     <string name="action_upload_error">Ngarkimi dështoi</string>
@@ -519,7 +519,7 @@
     <!-- Search providers -->
     <string name="search_provider_app_search">App search</string>
     <string name="search_provider_custom">E veqantë</string>
-    <string name="search_provider_sponsored_description">%1$s and Lawnchair have a revenue share agreement.\n\nSearching with %1$s helps support Lawnchair.</string>
+    <string name="search_provider_sponsored_description">%1$s and Asistent i AI have a revenue share agreement.\n\nSearching with %1$s helps support Asistent i AI.</string>
     <string name="app_label">Aplikacioni</string>
     <string name="website_label">Faqja e internetit</string>
     <string name="qsb_search_provider_app_required">App required</string>
@@ -552,7 +552,7 @@
     <string name="max_folder_columns">Maximum folder columns</string>
     <string name="max_folder_rows">Maximum folder rows</string>
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">These settings will be ignored as Lawnchair isn\'t set as the Recents screen provider</string>
+    <string name="quickswitch_ignored_warning">These settings will be ignored as Asistent i AI isn\'t set as the Recents screen provider</string>
     <string name="quickstep_incompatible">Incompatible system integration</string>
     <string name="quickstep_incompatible_description">Your device is configured to have system gestures (known as Quickstep) provided by %1$s, but this version of %1$s isn\'t compatible with your Android version. To continue using your device, please uninstall %1$s updates or disable %1$s as a system gesture provider.</string>
     <string name="translucent_background">Translucent background</string>

--- a/lawnchair/res/values-sq/strings.xml
+++ b/lawnchair/res/values-sq/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, Asistent i AI
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-sr/strings.xml
+++ b/lawnchair/res/values-sr/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, Аи асистент
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@
     <string name="time_weeks_ago">%dw</string>
     <string name="time_months_ago">%dmo</string>
     <string name="time_years_ago">%dy</string>
-    <string name="managed_by_lawnchair">Управља Lawnchair</string>
+    <string name="managed_by_lawnchair">Управља Аи асистент</string>
     <!-- When mentioning settings UI -->
     <string name="smartspace_preferences">Подешавања</string>
     <string name="settings_button_text">Подешавања почетног екрана</string>
@@ -69,7 +69,7 @@
     <string name="title_change_settings">Промените подешавања</string>
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout Аи асистент
 
     -->
     <string name="others_category_label">Остало</string>
@@ -114,7 +114,7 @@
     <string name="folders_filter_duplicates">Приказуј само апликације које се не понављају</string>
     <string name="my_folder_label">Мој фолдер</string>
     <!-- A11y description -->
-    <string name="accessibility_service_description">Да бисте извршили одређене радње (попут закључавања уређаја) покретом, Lawnchair-у је потребан приступ услузи приступачности.\n\nПомоћу ње се могу надгледати корисничке радње, али је Lawnchair не користи у те сврхе.</string>
+    <string name="accessibility_service_description">Да бисте извршили одређене радње (попут закључавања уређаја) покретом, Аи асистент-у је потребан приступ услузи приступачности.\n\nПомоћу ње се могу надгледати корисничке радње, али је Аи асистент не користи у те сврхе.</string>
     <string name="x_with_y_count">%1$s (%2$d)</string>
     <string name="x_by_y">%1$d x %2$d</string>
     <string name="x_and_y">%1$s и %2$s</string>
@@ -143,7 +143,7 @@
     <string name="quickstep_description">Дугме „Обриши све”, заобљеност углова</string>
     <string name="about_label">О апликацији</string>
     <string name="app_info_drop_target_label">Информације о апликацији</string>
-    <string name="debug_restart_launcher">Рестартуј Lawnchair</string>
+    <string name="debug_restart_launcher">Рестартуј Аи асистент</string>
     <string name="experimental_features_label">Експерименталне функције</string>
     <!-- Experimental features -->
     <string name="font_picker_label">Прилагођавање фонта</string>
@@ -171,7 +171,7 @@
     Notifications
 
     -->
-    <string name="set_default_launcher_tip">Да бисте приступали пречицама и другим функцијама, подесите Lawnchair као подразумевани покретач</string>
+    <string name="set_default_launcher_tip">Да бисте приступали пречицама и другим функцијама, подесите Аи асистент као подразумевани покретач</string>
     <string name="notification_dots">Тачке за обавештења</string>
     <string name="show_notification_count">Приказуј број обавештења</string>
     <string name="notification_dots_color">Боја тачке за обавештења</string>
@@ -344,7 +344,7 @@
     <string name="event_provider_missing_notification_dots">Да бисте користили „<xliff:g example="My Provider" id="providerName">%1$s</xliff:g>”, укључите тачке за обавештења.</string>
     <!-- Toggle button for enabling Smartspace -->
     <string name="smartspace_widget_toggle_label">Прикажи на почетном екрану</string>
-    <string name="smartspace_widget_toggle_description">„Кратак преглед” можете да додате ручно постављањем виџета „Lawnchair”</string>
+    <string name="smartspace_widget_toggle_description">„Кратак преглед” можете да додате ручно постављањем виџета „Аи асистент”</string>
     <!-- List of available providers -->
     <string name="smartspace_mode_label">Добављач за „Кратак преглед”</string>
     <string name="smartspace_mode_google">Google</string>
@@ -415,18 +415,18 @@
     <string name="gesture_handler_open_assistant">Отвори помоћника</string>
     <string name="pick_app_for_gesture">Изаберите апликацију</string>
     <string name="dt2s_admin_hint_title">Потребне су администраторске дозволе</string>
-    <string name="dt2s_admin_hint">Да бисте користили функцију „Додирните двапут за стање спавања”, подесите Lawnchair као администратор уређаја. У подешавањима додирните „Активирај ову апликацију за администратора уређаја”.</string>
+    <string name="dt2s_admin_hint">Да бисте користили функцију „Додирните двапут за стање спавања”, подесите Аи асистент као администратор уређаја. У подешавањима додирните „Активирај ову апликацију за администратора уређаја”.</string>
     <string name="dt2s_admin_warning">Функција „Додирните двапут за стање спавања” ће бити искључена</string>
     <string name="d2ts_recents_a11y_hint_title">Укључи услугу приступачности</string>
-    <string name="dt2s_a11y_hint">Да бисте користили функцију „Додирните двапут за стање спавања”, укључите Lawnchair-ову услугу приступачности. Додирните „Отвори подешавања”, изаберите „Lawnchair” и укључите „Користи Lawnchair”.\n\nОва дозвола је осетљива јер омогућава надгледање других апликација, али је Lawnchair не користи у те сврхе.</string>
+    <string name="dt2s_a11y_hint">Да бисте користили функцију „Додирните двапут за стање спавања”, укључите Аи асистент-ову услугу приступачности. Додирните „Отвори подешавања”, изаберите „Аи асистент” и укључите „Користи Аи асистент”.\n\nОва дозвола је осетљива јер омогућава надгледање других апликација, али је Аи асистент не користи у те сврхе.</string>
     <string name="dt2s_recents_warning_open_settings">Отвори подешавања</string>
-    <string name="recents_a11y_hint">Да бисте користили функцију „Отвори недавне апликације”, укључите Lawnchair-ову услугу приступачности. Додирните „Отвори подешавања”, изаберите „Lawnchair” и укључите „Користи Lawnchair”.\n\nОва дозвола је осетљива јер омогућава надгледање других апликација, али је Lawnchair не користи у те сврхе.</string>
+    <string name="recents_a11y_hint">Да бисте користили функцију „Отвори недавне апликације”, укључите Аи асистент-ову услугу приступачности. Додирните „Отвори подешавања”, изаберите „Аи асистент” и укључите „Користи Аи асистент”.\n\nОва дозвола је осетљива јер омогућава надгледање других апликација, али је Аи асистент не користи у те сврхе.</string>
     <!--
 
     Bug reporting
 
     -->
-    <string name="lawnchair_bug_report">Извештај о грешци у Lawnchair-у</string>
+    <string name="lawnchair_bug_report">Извештај о грешци у Аи асистент-у</string>
     <string name="crash_report_notif_title">%1$s је отказао</string>
     <string name="action_upload_crash_report">Отпреми евиденцију о отказивању</string>
     <string name="action_upload_error">Отпремање није успело</string>
@@ -519,7 +519,7 @@
     <!-- Search providers -->
     <string name="search_provider_app_search">Претрага апликација</string>
     <string name="search_provider_custom">Прилагођена</string>
-    <string name="search_provider_sponsored_description">%1$s и Lawnchair имају уговор о подели прихода.\n\nПретраживањем помоћу услуге %1$s подржавате Lawnchair.</string>
+    <string name="search_provider_sponsored_description">%1$s и Аи асистент имају уговор о подели прихода.\n\nПретраживањем помоћу услуге %1$s подржавате Аи асистент.</string>
     <string name="app_label">Апликација</string>
     <string name="website_label">Сајт</string>
     <string name="qsb_search_provider_app_required">Потребна је апликација</string>
@@ -553,7 +553,7 @@
     <string name="max_folder_columns">Максималан број колона у фолдеру</string>
     <string name="max_folder_rows">Максималан број редова у фолдеру</string>
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">Ова подешавања ће бити игнорисана јер Lawnchair није подешен као добављач недавних апликација</string>
+    <string name="quickswitch_ignored_warning">Ова подешавања ће бити игнорисана јер Аи асистент није подешен као добављач недавних апликација</string>
     <string name="quickstep_incompatible">Некомпатибилна системска интеграција</string>
     <string name="quickstep_incompatible_description">Уређај је подешен да користи системске покрете (познате као Quickstep), које пружа %1$s, али ова верзија %1$s-а није компатибилна са вашом верзијом Android-а. Да бисте наставили да користите уређај, деинсталирајте ажурирања %1$s-а или онемогућите %1$s као добављача системских покрета.</string>
     <string name="translucent_background">Полупрозирна позадина</string>

--- a/lawnchair/res/values-sv-rSE/strings.xml
+++ b/lawnchair/res/values-sv-rSE/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI -assistent
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@
     <string name="time_weeks_ago">%d vkr</string>
     <string name="time_months_ago">%d mån</string>
     <string name="time_years_ago">%d år</string>
-    <string name="managed_by_lawnchair">Hanteras av Lawnchair</string>
+    <string name="managed_by_lawnchair">Hanteras av AI -assistent</string>
     <!-- When mentioning settings UI -->
     <string name="smartspace_preferences">Alternativ</string>
     <string name="settings_button_text">Startinställningar</string>
@@ -69,7 +69,7 @@
     <string name="title_change_settings">Ändra inställningar</string>
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout AI -assistent
 
     -->
     <string name="others_category_label">Övriga</string>
@@ -114,7 +114,7 @@
     <string name="folders_filter_duplicates">Visa endast unika appar</string>
     <string name="my_folder_label">Min mapp</string>
     <!-- A11y description -->
-    <string name="accessibility_service_description">För att kunna utföra vissa åtgärder (såsom att låsa din telefon) när en gest görs, kräver Lawnchair tillgänglighetsåtkomst.\n\nLawnchair övervakar inte några användaraktiviteter, men behörigheten att kunna göra detta krävs för alla tillgänglighetstjänster. Lawnchair ignorerar alla händelser som skickas av systemet.\n\nFör att kunna låsa din telefon eller öppna Senaste-skärmen använder Lawnchair tillgänglighetstjänsten performGlobalAction.</string>
+    <string name="accessibility_service_description">För att kunna utföra vissa åtgärder (såsom att låsa din telefon) när en gest görs, kräver AI -assistent tillgänglighetsåtkomst.\n\nAI -assistent övervakar inte några användaraktiviteter, men behörigheten att kunna göra detta krävs för alla tillgänglighetstjänster. AI -assistent ignorerar alla händelser som skickas av systemet.\n\nFör att kunna låsa din telefon eller öppna Senaste-skärmen använder AI -assistent tillgänglighetstjänsten performGlobalAction.</string>
     <string name="x_with_y_count">%1$s (%2$d)</string>
     <string name="x_by_y">%1$d x %2$d</string>
     <string name="x_and_y">%1$s &amp; %2$s</string>
@@ -143,7 +143,7 @@
     <string name="quickstep_description">Rensa alla-knapp, hörnradie</string>
     <string name="about_label">Om</string>
     <string name="app_info_drop_target_label">Appinfo</string>
-    <string name="debug_restart_launcher">Starta om Lawnchair</string>
+    <string name="debug_restart_launcher">Starta om AI -assistent</string>
     <string name="experimental_features_label">Experimentella funktioner</string>
     <!-- Experimental features -->
     <string name="font_picker_label">Anpassning av typsnitt</string>
@@ -171,7 +171,7 @@
     Notifications
 
     -->
-    <string name="set_default_launcher_tip">För att komma åt genvägar och ytterligare funktioner, ange Lawnchair som din förvalda startskärmsapp</string>
+    <string name="set_default_launcher_tip">För att komma åt genvägar och ytterligare funktioner, ange AI -assistent som din förvalda startskärmsapp</string>
     <string name="notification_dots">Aviseringsprickar</string>
     <string name="show_notification_count">Visa aviseringsräknare</string>
     <string name="notification_dots_color">Aviseringsprickens färg</string>
@@ -344,7 +344,7 @@
     <string name="event_provider_missing_notification_dots">För att använda <xliff:g example="My Provider" id="providerName">%1$s</xliff:g>, aktivera aviseringsprickar.</string>
     <!-- Toggle button for enabling Smartspace -->
     <string name="smartspace_widget_toggle_label">Visa på startskärmen</string>
-    <string name="smartspace_widget_toggle_description">Snabböversikt kan läggas till manuellt på startskärmen genom att placera ut Lawnchair-widgeten</string>
+    <string name="smartspace_widget_toggle_description">Snabböversikt kan läggas till manuellt på startskärmen genom att placera ut AI -assistent-widgeten</string>
     <!-- List of available providers -->
     <string name="smartspace_mode_label">Snabböversiktsleverantör</string>
     <string name="smartspace_mode_google">Google</string>
@@ -415,18 +415,18 @@
     <string name="gesture_handler_open_assistant">Öppna assistent</string>
     <string name="pick_app_for_gesture">Välj app</string>
     <string name="dt2s_admin_hint_title">Adminbehörigheter krävs</string>
-    <string name="dt2s_admin_hint">För att använda Dubbeltryck för att vila, ange Lawnchair som en enhetsadminapp. Tryck på \"Öppna inställningar\", tryck sedan på \"Aktivera denna enhetsadminapp\".</string>
+    <string name="dt2s_admin_hint">För att använda Dubbeltryck för att vila, ange AI -assistent som en enhetsadminapp. Tryck på \"Öppna inställningar\", tryck sedan på \"Aktivera denna enhetsadminapp\".</string>
     <string name="dt2s_admin_warning">Dubbeltryck för att vila kommer att inaktiveras.</string>
     <string name="d2ts_recents_a11y_hint_title">Aktivera tillgänglighetstjänst</string>
-    <string name="dt2s_a11y_hint">För att använda Dubbeltryck för att vila, aktivera Lawnchairs tillgänglighetstjänst. Tryck på \"Öppna inställningar\", välj \"Lawnchair\" och aktivera \"Använd Lawnchair\".\n\nLawnchair använder Tillgänglighets `performGlobalAction`-metod för att utföra denna åtgärd. Detta är en känslig behörighet som tillåter övervakning av andra appar. Lawnchair är dock inte konfigurerad för den funktionen och tar inte emot några händelser.</string>
+    <string name="dt2s_a11y_hint">För att använda Dubbeltryck för att vila, aktivera AI -assistents tillgänglighetstjänst. Tryck på \"Öppna inställningar\", välj \"AI -assistent\" och aktivera \"Använd AI -assistent\".\n\nAI -assistent använder Tillgänglighets `performGlobalAction`-metod för att utföra denna åtgärd. Detta är en känslig behörighet som tillåter övervakning av andra appar. AI -assistent är dock inte konfigurerad för den funktionen och tar inte emot några händelser.</string>
     <string name="dt2s_recents_warning_open_settings">Öppna inställningar</string>
-    <string name="recents_a11y_hint">För att använda Öppna Senaste-skärm, aktivera Lawnchairs tillgänglighetstjänst. Tryck på \"Öppna inställningar\", välj \"Lawnchair\" och aktivera \"Använd Lawnchair\".\n\nLawnchair använder Tillgänglighets `performGlobalAction`-metod för att utföra denna åtgärd. Detta är en känslig behörighet som tillåter övervakning av andra appar. Lawnchair är dock inte konfigurerad för den funktionen och tar inte emot några händelser.</string>
+    <string name="recents_a11y_hint">För att använda Öppna Senaste-skärm, aktivera AI -assistents tillgänglighetstjänst. Tryck på \"Öppna inställningar\", välj \"AI -assistent\" och aktivera \"Använd AI -assistent\".\n\nAI -assistent använder Tillgänglighets `performGlobalAction`-metod för att utföra denna åtgärd. Detta är en känslig behörighet som tillåter övervakning av andra appar. AI -assistent är dock inte konfigurerad för den funktionen och tar inte emot några händelser.</string>
     <!--
 
     Bug reporting
 
     -->
-    <string name="lawnchair_bug_report">Buggrapport för Lawnchair</string>
+    <string name="lawnchair_bug_report">Buggrapport för AI -assistent</string>
     <string name="crash_report_notif_title">%1$s kraschade</string>
     <string name="action_upload_crash_report">Ladda upp kraschlogg</string>
     <string name="action_upload_error">Uppladdningen misslyckades</string>
@@ -519,7 +519,7 @@
     <!-- Search providers -->
     <string name="search_provider_app_search">Appsökning</string>
     <string name="search_provider_custom">Anpassad</string>
-    <string name="search_provider_sponsored_description">%1$s och Lawnchair har ett avtal om intäktsdelning.\n\nSökning med %1$s hjälper till att stödja Lawnchair.</string>
+    <string name="search_provider_sponsored_description">%1$s och AI -assistent har ett avtal om intäktsdelning.\n\nSökning med %1$s hjälper till att stödja AI -assistent.</string>
     <string name="app_label">App</string>
     <string name="website_label">Webbplats</string>
     <string name="qsb_search_provider_app_required">App krävs</string>
@@ -552,7 +552,7 @@
     <string name="max_folder_columns">Maximalt antal mappkolumner</string>
     <string name="max_folder_rows">Maximalt antal mapprader</string>
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">Dessa inställningar kommer att ignoreras eftersom Lawnchair inte är inställd som Senaste-skärmsleverantör</string>
+    <string name="quickswitch_ignored_warning">Dessa inställningar kommer att ignoreras eftersom AI -assistent inte är inställd som Senaste-skärmsleverantör</string>
     <string name="quickstep_incompatible">Inkompatibel systemintegration</string>
     <string name="quickstep_incompatible_description">Din enhet är konfigurerad för att ha systemgester (kända som Quickstep) tillhandahållna av %1$s, men denna version av %1$s är inte kompatibel med din Android-version. För att fortsätta att använda din enhet, vänligen avinstallera uppdateringar till %1$s eller inaktivera %1$s som systemgestsleverantör.</string>
     <string name="translucent_background">Genomlysande bakgrund</string>

--- a/lawnchair/res/values-sv/strings.xml
+++ b/lawnchair/res/values-sv/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI -assistent
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-sw-rKE/strings.xml
+++ b/lawnchair/res/values-sw-rKE/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, Msaidizi wa AI
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@
     <string name="time_weeks_ago">%dw</string>
     <string name="time_months_ago">%dmo</string>
     <string name="time_years_ago">%dy</string>
-    <string name="managed_by_lawnchair">Inasimamiwa na Lawnchair</string>
+    <string name="managed_by_lawnchair">Inasimamiwa na Msaidizi wa AI</string>
     <!-- When mentioning settings UI -->
     <string name="smartspace_preferences">Mapendeleo</string>
     <string name="settings_button_text">Home settings</string>
@@ -69,7 +69,7 @@
     <string name="title_change_settings">Change settings</string>
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout Msaidizi wa AI
 
     -->
     <string name="others_category_label">Others</string>
@@ -114,7 +114,7 @@
     <string name="folders_filter_duplicates">Only show unique apps</string>
     <string name="my_folder_label">My folder</string>
     <!-- A11y description -->
-    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, Lawnchair uses the performGlobalAction Accessibility service.</string>
+    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, Msaidizi wa AI requires accessibility access.\n\nMsaidizi wa AI doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Msaidizi wa AI discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, Msaidizi wa AI uses the performGlobalAction Accessibility service.</string>
     <string name="x_with_y_count">%1$s (%2$d)</string>
     <string name="x_by_y">%1$d x %2$d</string>
     <string name="x_and_y">%1$s &amp; %2$s</string>
@@ -143,7 +143,7 @@
     <string name="quickstep_description">Clear All button, corner radius</string>
     <string name="about_label">Kuhusu</string>
     <string name="app_info_drop_target_label">App info</string>
-    <string name="debug_restart_launcher">Anzisha Lawnchair</string>
+    <string name="debug_restart_launcher">Anzisha Msaidizi wa AI</string>
     <string name="experimental_features_label">Experimental features</string>
     <!-- Experimental features -->
     <string name="font_picker_label">Font customization</string>
@@ -171,7 +171,7 @@
     Notifications
 
     -->
-    <string name="set_default_launcher_tip">To access shortcuts and additional features, set Lawnchair as your default launcher</string>
+    <string name="set_default_launcher_tip">To access shortcuts and additional features, set Msaidizi wa AI as your default launcher</string>
     <string name="notification_dots">Notification dots</string>
     <string name="show_notification_count">Show notification counter</string>
     <string name="notification_dots_color">Notification dot color</string>
@@ -344,7 +344,7 @@
     <string name="event_provider_missing_notification_dots">To use <xliff:g example="My Provider" id="providerName">%1$s</xliff:g>, turn on Notification Dots.</string>
     <!-- Toggle button for enabling Smartspace -->
     <string name="smartspace_widget_toggle_label">Show on home screen</string>
-    <string name="smartspace_widget_toggle_description">At a Glance can be manually added to the home screen by placing the Lawnchair widget</string>
+    <string name="smartspace_widget_toggle_description">At a Glance can be manually added to the home screen by placing the Msaidizi wa AI widget</string>
     <!-- List of available providers -->
     <string name="smartspace_mode_label">At a Glance provider</string>
     <string name="smartspace_mode_google">Google</string>
@@ -415,18 +415,18 @@
     <string name="gesture_handler_open_assistant">Open assistant</string>
     <string name="pick_app_for_gesture">Pick app</string>
     <string name="dt2s_admin_hint_title">Admin permissions required</string>
-    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set Lawnchair as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
+    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set Msaidizi wa AI as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
     <string name="dt2s_admin_warning">Gusa Mara mbili ili Ulale itazimwa.</string>
     <string name="d2ts_recents_a11y_hint_title">Turn on accessibility service</string>
-    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the Msaidizi wa AI accessibility service. Tap \"Open settings\", select \"Msaidizi wa AI\" and turn on \"Use Msaidizi wa AI.\"\n\nMsaidizi wa AI uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Msaidizi wa AI is not configured for that functionality and receives no events.</string>
     <string name="dt2s_recents_warning_open_settings">Open settings</string>
-    <string name="recents_a11y_hint">To use Open Recents screen, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="recents_a11y_hint">To use Open Recents screen, turn on the Msaidizi wa AI accessibility service. Tap \"Open settings\", select \"Msaidizi wa AI\" and turn on \"Use Msaidizi wa AI.\"\n\nMsaidizi wa AI uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Msaidizi wa AI is not configured for that functionality and receives no events.</string>
     <!--
 
     Bug reporting
 
     -->
-    <string name="lawnchair_bug_report">Lawnchair bug report</string>
+    <string name="lawnchair_bug_report">Msaidizi wa AI bug report</string>
     <string name="crash_report_notif_title">%1$s crashed</string>
     <string name="action_upload_crash_report">Upload crash log</string>
     <string name="action_upload_error">Upload imeshindwa</string>
@@ -519,7 +519,7 @@
     <!-- Search providers -->
     <string name="search_provider_app_search">App search</string>
     <string name="search_provider_custom">Ubinafsishaji</string>
-    <string name="search_provider_sponsored_description">%1$s and Lawnchair have a revenue share agreement.\n\nSearching with %1$s helps support Lawnchair.</string>
+    <string name="search_provider_sponsored_description">%1$s and Msaidizi wa AI have a revenue share agreement.\n\nSearching with %1$s helps support Msaidizi wa AI.</string>
     <string name="app_label">Programu</string>
     <string name="website_label">Tovuti</string>
     <string name="qsb_search_provider_app_required">App required</string>
@@ -552,7 +552,7 @@
     <string name="max_folder_columns">Maximum folder columns</string>
     <string name="max_folder_rows">Maximum folder rows</string>
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">These settings will be ignored as Lawnchair isn\'t set as the Recents screen provider</string>
+    <string name="quickswitch_ignored_warning">These settings will be ignored as Msaidizi wa AI isn\'t set as the Recents screen provider</string>
     <string name="quickstep_incompatible">Incompatible system integration</string>
     <string name="quickstep_incompatible_description">Your device is configured to have system gestures (known as Quickstep) provided by %1$s, but this version of %1$s isn\'t compatible with your Android version. To continue using your device, please uninstall %1$s updates or disable %1$s as a system gesture provider.</string>
     <string name="translucent_background">Translucent background</string>

--- a/lawnchair/res/values-sw/strings.xml
+++ b/lawnchair/res/values-sw/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2022, Lawnchair
+  ~ Copyright 2022, Msaidizi wa AI
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@
     <!-- <string name="version" /> (unknown source) -->
     <!-- PreferencesOverflowMenu() in PreferencesDashboard -->
     <string name="app_info_drop_target_label">Maelezo ya Programu</string>
-    <string name="debug_restart_launcher">Anzisha Lawnchair</string>
+    <string name="debug_restart_launcher">Anzisha Msaidizi wa AI</string>
     <string name="experimental_features_label">Vipengele vya Majaribio</string>
     <!-- ExperimentalFeaturesPreferences -->
     <!-- <string name="experimental_features_label" />-->
@@ -160,7 +160,7 @@
     <string name="action_paste">Bandika</string>
     <string name="copied_toast">Imenakiliwa kwenye ubao wa kunakili.</string>
     <string name="invalid_color">Rangi batili</string>
-    <string name="launcher_default_color">Inasimamiwa na Lawnchair</string>
+    <string name="launcher_default_color">Inasimamiwa na Msaidizi wa AI</string>
     <!-- HomeScreenPreferences -->
     <!-- <string name="general_label" /> -->
     <string name="auto_add_shortcuts_label">Ongeza Programu Mpya kwenye Skrini ya Nyumbani</string>
@@ -229,16 +229,16 @@
     <string name="smartspace_calendar_persian">Kiajemi</string>
     <string name="smartspace_preferences">Mapendeleo</string>
     <string name="smartspace_widget_toggle_label">Onyesha kwenye Skrini ya Nyumbani</string>
-    <string name="smartspace_widget_toggle_description">Kwa Mtazamo inaweza kuongezwa kwa mikono kwa kuwekan\"Lawnchair \" wijeti.</string>
+    <string name="smartspace_widget_toggle_description">Kwa Mtazamo inaweza kuongezwa kwa mikono kwa kuwekan\"Msaidizi wa AI \" wijeti.</string>
     <string name="smartspace_mode_label">Kwa Mtazamo Mhudumu</string>
-    <string name="smartspace_mode_lawnchair">Lawnchair</string>
+    <string name="smartspace_mode_lawnchair">Msaidizi wa AI</string>
     <string name="smartspace_mode_google">Google</string>
     <string name="smartspace_mode_google_search">Utafutaji wa Google</string>
     <!-- DockPreferences -->
     <!-- <string name="dock_label" /> -->
     <string name="hotseat_mode_label">Wijeti ya Upau wa Utafutaji</string>
     <string name="hotseat_mode_disabled">Imezimwa</string>
-    <string name="hotseat_mode_lawnchair">Lawnchair</string>
+    <string name="hotseat_mode_lawnchair">Msaidizi wa AI</string>
     <string name="hotseat_mode_google_search">Upau wa Utafutaji wa Google</string>
     <string name="search_bar_label">Upau wa Utafutaji</string>
     <string name="corner_radius_label">Radi ya kona</string>
@@ -345,10 +345,10 @@
     <string name="item_removed">Kipengee kimeondolewa.</string>
     <string name="all_apps_no_search_results">Hakuna programu zilizopatikana zinazolingana \"<xliff:g example="Android" id="query">%1$s</xliff:g>\".</string>
     <string name="dt2s_admin_hint_title">Ruhusa za Msimamizi Zinahitajika</string>
-    <string name="dt2s_admin_hint">Ili kutumia Gusa Mara Mbili ili Kulala, weka Lawnchair kama programu ya msimamizi wa kifaa. Gusa Fungua Mipangilio, kisha uguse \"Washa programu ya msimamizi wa kifaa hiki.\"</string>
+    <string name="dt2s_admin_hint">Ili kutumia Gusa Mara Mbili ili Kulala, weka Msaidizi wa AI kama programu ya msimamizi wa kifaa. Gusa Fungua Mipangilio, kisha uguse \"Washa programu ya msimamizi wa kifaa hiki.\"</string>
     <string name="dt2s_admin_warning">Gusa Mara mbili ili Ulale itazimwa.</string>
     <string name="dt2s_a11y_hint_title">Washa Huduma ya Ufikiaji</string>
-    <string name="dt2s_a11y_hint">Ili kutumia Gusa Mara Mbili ili Ulale, washa huduma ya ufikiaji wa Lawnchair. Gusa Fungua Mipangilio, kisha uchague Lawnchair na uwashe Tumia Lawnchair.</string>
+    <string name="dt2s_a11y_hint">Ili kutumia Gusa Mara Mbili ili Ulale, washa huduma ya ufikiaji wa Msaidizi wa AI. Gusa Fungua Mipangilio, kisha uchague Msaidizi wa AI na uwashe Tumia Msaidizi wa AI.</string>
     <string name="dt2s_warning_open_settings">Fungua mfumo</string>
     <string name="loading">Inapakia…</string>
     <string name="system">Mfumo</string>
@@ -357,7 +357,7 @@
     <string name="hide_from_drawer">Ficha kutoka kwenye Droo ya Programu</string>
     <string name="suggestion_pref_screen_title">Suggestions</string>
     <!-- Bug reporting -->
-    <string name="lawnchair_bug_report">Ripoti ya Hitilafu ya Lawnchair</string>
+    <string name="lawnchair_bug_report">Ripoti ya Hitilafu ya Msaidizi wa AI</string>
     <string name="crash_report_notif_title">%1$s Imesimama Ghafla</string>
     <string name="action_upload_crash_report">Pakia kumbukumbu ya kuacha kufanya kazi</string>
     <string name="action_copy_link">Nakili kiungo</string>

--- a/lawnchair/res/values-ta-rIN/strings.xml
+++ b/lawnchair/res/values-ta-rIN/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI உதவியாளர்
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -69,7 +69,7 @@
     <string name="title_change_settings">அமைப்புகளை மாற்று</string>
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout AI உதவியாளர்
 
     -->
     <string name="others_category_label">Others</string>
@@ -114,7 +114,7 @@
     <string name="folders_filter_duplicates">Only show unique apps</string>
     <string name="my_folder_label">My folder</string>
     <!-- A11y description -->
-    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, Lawnchair uses the performGlobalAction Accessibility service.</string>
+    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, AI உதவியாளர் requires accessibility access.\n\nAI உதவியாளர் doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. AI உதவியாளர் discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, AI உதவியாளர் uses the performGlobalAction Accessibility service.</string>
     <string name="x_with_y_count">%1$s (%2$d)</string>
     <string name="x_by_y">%1$d x %2$d</string>
     <string name="x_and_y">%1$s &amp; %2$s</string>
@@ -143,7 +143,7 @@
     <string name="quickstep_description">அனைத்தயுந்துடை பொத்தான், மூலை ஆரம்</string>
     <string name="about_label">விவர பெயர்கள்</string>
     <string name="app_info_drop_target_label">செயலியின் தகவல்கள்</string>
-    <string name="debug_restart_launcher">Lawnchairஐ மறுதுவக்கு</string>
+    <string name="debug_restart_launcher">AI உதவியாளர்ஐ மறுதுவக்கு</string>
     <string name="experimental_features_label">பரீட்சார்த்த அம்சங்கள்</string>
     <!-- Experimental features -->
     <string name="font_picker_label">எழுத்துரு தனிப்பயனாக்கம்</string>
@@ -171,7 +171,7 @@
     Notifications
 
     -->
-    <string name="set_default_launcher_tip">குறுக்குவழிகள் மற்றும் கூடுதல் அம்சங்களை அணுக, Lawnchair ஐ உங்கள் இயல்புநிலை துவக்கியாக அமைக்கவும்</string>
+    <string name="set_default_launcher_tip">குறுக்குவழிகள் மற்றும் கூடுதல் அம்சங்களை அணுக, AI உதவியாளர் ஐ உங்கள் இயல்புநிலை துவக்கியாக அமைக்கவும்</string>
     <string name="notification_dots">அறிவிப்புப் புள்ளிகள்</string>
     <string name="show_notification_count">அறிவிப்புகளின் எண்ணிக்கையைக் காண்பி</string>
     <string name="notification_dots_color">அறிவிப்பு புள்ளிகளின் வண்ணம்</string>
@@ -344,7 +344,7 @@
     <string name="event_provider_missing_notification_dots">To use <xliff:g example="My Provider" id="providerName">%1$s</xliff:g>, turn on Notification Dots.</string>
     <!-- Toggle button for enabling Smartspace -->
     <string name="smartspace_widget_toggle_label">முகப்புத் திரையில் காட்டு</string>
-    <string name="smartspace_widget_toggle_description">Lawnchair விட்ஜெட்டை வைப்பதன் மூலம் முகப்புத் திரையில் At a Glance யைச் சேர்க்கலாம்</string>
+    <string name="smartspace_widget_toggle_description">AI உதவியாளர் விட்ஜெட்டை வைப்பதன் மூலம் முகப்புத் திரையில் At a Glance யைச் சேர்க்கலாம்</string>
     <!-- List of available providers -->
     <string name="smartspace_mode_label">At a Glance வழங்குநர்</string>
     <string name="smartspace_mode_google">கூகிள்</string>
@@ -415,18 +415,18 @@
     <string name="gesture_handler_open_assistant">Open assistant</string>
     <string name="pick_app_for_gesture">செயலியைத் தேர்ந்தெடு</string>
     <string name="dt2s_admin_hint_title">நிர்வாக அனுமதி தேவை</string>
-    <string name="dt2s_admin_hint">அணைக்க இரட்டைத்தட்டலைப் பயன்படுத்த Lawnchairஐச் சாதன நிர்வாகிச் செயலியாக அமை. அமைப்பைத் திற என்பதைத் தட்டி, “இந்தச் சாதன நிர்வாகி ஆப்ஸைச் செயல்படுத்து” என்பதைத் தட்டுக</string>
+    <string name="dt2s_admin_hint">அணைக்க இரட்டைத்தட்டலைப் பயன்படுத்த AI உதவியாளர்ஐச் சாதன நிர்வாகிச் செயலியாக அமை. அமைப்பைத் திற என்பதைத் தட்டி, “இந்தச் சாதன நிர்வாகி ஆப்ஸைச் செயல்படுத்து” என்பதைத் தட்டுக</string>
     <string name="dt2s_admin_warning">Double Tap to Sleep will be disabled.</string>
     <string name="d2ts_recents_a11y_hint_title">அணுகல்தன்மை சேவையை இயக்கு</string>
-    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the AI உதவியாளர் accessibility service. Tap \"Open settings\", select \"AI உதவியாளர்\" and turn on \"Use AI உதவியாளர்.\"\n\nAI உதவியாளர் uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, AI உதவியாளர் is not configured for that functionality and receives no events.</string>
     <string name="dt2s_recents_warning_open_settings">அமைப்புகளைத் திற</string>
-    <string name="recents_a11y_hint">To use Open Recents screen, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="recents_a11y_hint">To use Open Recents screen, turn on the AI உதவியாளர் accessibility service. Tap \"Open settings\", select \"AI உதவியாளர்\" and turn on \"Use AI உதவியாளர்.\"\n\nAI உதவியாளர் uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, AI உதவியாளர் is not configured for that functionality and receives no events.</string>
     <!--
 
     Bug reporting
 
     -->
-    <string name="lawnchair_bug_report">Lawnchair பிழை அறிக்கை</string>
+    <string name="lawnchair_bug_report">AI உதவியாளர் பிழை அறிக்கை</string>
     <string name="crash_report_notif_title">%1$s சிதைந்தது</string>
     <string name="action_upload_crash_report">செயலிழப்பு பதிவைப் பதிவேற்றவும்</string>
     <string name="action_upload_error">பதிவேற்றம் தோல்வி</string>
@@ -519,7 +519,7 @@
     <!-- Search providers -->
     <string name="search_provider_app_search">செயலி தேடல்</string>
     <string name="search_provider_custom">தனிப்பயன்</string>
-    <string name="search_provider_sponsored_description">%1$s மற்றும் Lawnchair வருவாய் பகிர்வு ஒப்பந்தத்தைக் கொண்டுள்ளன.\n\n%1$s உடன் தேடுவது Lawnchair ஐ ஆதரிக்க உதவுகிறது.</string>
+    <string name="search_provider_sponsored_description">%1$s மற்றும் AI உதவியாளர் வருவாய் பகிர்வு ஒப்பந்தத்தைக் கொண்டுள்ளன.\n\n%1$s உடன் தேடுவது AI உதவியாளர் ஐ ஆதரிக்க உதவுகிறது.</string>
     <string name="app_label">செயலி</string>
     <string name="website_label">இணையதளம்</string>
     <string name="qsb_search_provider_app_required">செயலி தேவை</string>
@@ -552,7 +552,7 @@
     <string name="max_folder_columns">அதிகபட்ச கோப்புறை நெடுவரிசைகள்</string>
     <string name="max_folder_rows">அதிகபட்ச கோப்புறை நெடுவரிசைகள்</string>
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">These settings will be ignored as Lawnchair isn\'t set as the Recents screen provider</string>
+    <string name="quickswitch_ignored_warning">These settings will be ignored as AI உதவியாளர் isn\'t set as the Recents screen provider</string>
     <string name="quickstep_incompatible">பொருந்தாத கணினி ஒருங்கிணைப்பு</string>
     <string name="quickstep_incompatible_description">%1$s -ஆல் வழங்கப்பட்ட முறைமை சைகைகளைக் (Quickstep என அறியப்படும்) கொண்டிருக்கும்படி உங்கள் சாதனம் உள்ளமைக்கப்பட்டுள்ளது, ஆனால் %1$s-இன் இந்தப் பதிப்பு உங்கள் Android பதிப்புடன் இணக்கமாக இல்லை. உங்கள் சாதனத்தைப் பயன்படுத்துவதைத் தொடர, முறைமை சைகை வழங்குநராக %1$s புதுப்பித்தல்களை நிறுவல்நீக்கவும் அல்லது %1$s -ஐ முடக்கவும்.</string>
     <string name="translucent_background">ஒளிஊடுருவக்கூடிய பின்னணி</string>

--- a/lawnchair/res/values-ta/strings.xml
+++ b/lawnchair/res/values-ta/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI உதவியாளர்
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-te-rIN/strings.xml
+++ b/lawnchair/res/values-te-rIN/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI అసిస్టెంట్
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@
     <string name="time_weeks_ago">%dw</string>
     <string name="time_months_ago">%dmo</string>
     <string name="time_years_ago">%dy</string>
-    <string name="managed_by_lawnchair">Managed by Lawnchair</string>
+    <string name="managed_by_lawnchair">Managed by AI అసిస్టెంట్</string>
     <!-- When mentioning settings UI -->
     <string name="smartspace_preferences">ప్రాధాన్యతలు</string>
     <string name="settings_button_text">Home settings</string>
@@ -69,7 +69,7 @@
     <string name="title_change_settings">Change settings</string>
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout AI అసిస్టెంట్
 
     -->
     <string name="others_category_label">Others</string>
@@ -114,7 +114,7 @@
     <string name="folders_filter_duplicates">Only show unique apps</string>
     <string name="my_folder_label">My folder</string>
     <!-- A11y description -->
-    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, Lawnchair uses the performGlobalAction Accessibility service.</string>
+    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, AI అసిస్టెంట్ requires accessibility access.\n\nAI అసిస్టెంట్ doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. AI అసిస్టెంట్ discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, AI అసిస్టెంట్ uses the performGlobalAction Accessibility service.</string>
     <string name="x_with_y_count">%1$s (%2$d)</string>
     <string name="x_by_y">%1$d x %2$d</string>
     <string name="x_and_y">%1$s &amp; %2$s</string>
@@ -143,7 +143,7 @@
     <string name="quickstep_description">Clear All button, corner radius</string>
     <string name="about_label">గురించి</string>
     <string name="app_info_drop_target_label">App info</string>
-    <string name="debug_restart_launcher">Restart Lawnchair</string>
+    <string name="debug_restart_launcher">Restart AI అసిస్టెంట్</string>
     <string name="experimental_features_label">Experimental features</string>
     <!-- Experimental features -->
     <string name="font_picker_label">Font customization</string>
@@ -171,7 +171,7 @@
     Notifications
 
     -->
-    <string name="set_default_launcher_tip">To access shortcuts and additional features, set Lawnchair as your default launcher</string>
+    <string name="set_default_launcher_tip">To access shortcuts and additional features, set AI అసిస్టెంట్ as your default launcher</string>
     <string name="notification_dots">Notification dots</string>
     <string name="show_notification_count">Show notification counter</string>
     <string name="notification_dots_color">Notification dot color</string>
@@ -344,7 +344,7 @@
     <string name="event_provider_missing_notification_dots">To use <xliff:g example="My Provider" id="providerName">%1$s</xliff:g>, turn on Notification Dots.</string>
     <!-- Toggle button for enabling Smartspace -->
     <string name="smartspace_widget_toggle_label">Show on home screen</string>
-    <string name="smartspace_widget_toggle_description">At a Glance can be manually added to the home screen by placing the Lawnchair widget</string>
+    <string name="smartspace_widget_toggle_description">At a Glance can be manually added to the home screen by placing the AI అసిస్టెంట్ widget</string>
     <!-- List of available providers -->
     <string name="smartspace_mode_label">At a Glance provider</string>
     <string name="smartspace_mode_google">Google</string>
@@ -415,18 +415,18 @@
     <string name="gesture_handler_open_assistant">Open assistant</string>
     <string name="pick_app_for_gesture">Pick app</string>
     <string name="dt2s_admin_hint_title">Admin permissions required</string>
-    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set Lawnchair as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
+    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set AI అసిస్టెంట్ as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
     <string name="dt2s_admin_warning">Double-Tap to Sleep will be turned off.</string>
     <string name="d2ts_recents_a11y_hint_title">Turn on accessibility service</string>
-    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the AI అసిస్టెంట్ accessibility service. Tap \"Open settings\", select \"AI అసిస్టెంట్\" and turn on \"Use AI అసిస్టెంట్.\"\n\nAI అసిస్టెంట్ uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, AI అసిస్టెంట్ is not configured for that functionality and receives no events.</string>
     <string name="dt2s_recents_warning_open_settings">Open settings</string>
-    <string name="recents_a11y_hint">To use Open Recents screen, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="recents_a11y_hint">To use Open Recents screen, turn on the AI అసిస్టెంట్ accessibility service. Tap \"Open settings\", select \"AI అసిస్టెంట్\" and turn on \"Use AI అసిస్టెంట్.\"\n\nAI అసిస్టెంట్ uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, AI అసిస్టెంట్ is not configured for that functionality and receives no events.</string>
     <!--
 
     Bug reporting
 
     -->
-    <string name="lawnchair_bug_report">Lawnchair bug report</string>
+    <string name="lawnchair_bug_report">AI అసిస్టెంట్ bug report</string>
     <string name="crash_report_notif_title">%1$s crashed</string>
     <string name="action_upload_crash_report">Upload crash log</string>
     <string name="action_upload_error">Upload failed</string>
@@ -519,7 +519,7 @@
     <!-- Search providers -->
     <string name="search_provider_app_search">App search</string>
     <string name="search_provider_custom">Custom</string>
-    <string name="search_provider_sponsored_description">%1$s and Lawnchair have a revenue share agreement.\n\nSearching with %1$s helps support Lawnchair.</string>
+    <string name="search_provider_sponsored_description">%1$s and AI అసిస్టెంట్ have a revenue share agreement.\n\nSearching with %1$s helps support AI అసిస్టెంట్.</string>
     <string name="app_label">App</string>
     <string name="website_label">Website</string>
     <string name="qsb_search_provider_app_required">App required</string>
@@ -552,7 +552,7 @@
     <string name="max_folder_columns">Maximum folder columns</string>
     <string name="max_folder_rows">Maximum folder rows</string>
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">These settings will be ignored as Lawnchair isn\'t set as the Recents screen provider</string>
+    <string name="quickswitch_ignored_warning">These settings will be ignored as AI అసిస్టెంట్ isn\'t set as the Recents screen provider</string>
     <string name="quickstep_incompatible">Incompatible system integration</string>
     <string name="quickstep_incompatible_description">Your device is configured to have system gestures (known as Quickstep) provided by %1$s, but this version of %1$s isn\'t compatible with your Android version. To continue using your device, please uninstall %1$s updates or disable %1$s as a system gesture provider.</string>
     <string name="translucent_background">Translucent background</string>

--- a/lawnchair/res/values-te/strings.xml
+++ b/lawnchair/res/values-te/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI అసిస్టెంట్
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-th-rTH/strings.xml
+++ b/lawnchair/res/values-th-rTH/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, ผู้ช่วย AI
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@
     <string name="time_weeks_ago">%dw</string>
     <string name="time_months_ago">%dmo</string>
     <string name="time_years_ago">%dy</string>
-    <string name="managed_by_lawnchair">จัดการโดย Lawnchair</string>
+    <string name="managed_by_lawnchair">จัดการโดย ผู้ช่วย AI</string>
     <!-- When mentioning settings UI -->
     <string name="smartspace_preferences">ปรับแต่ง</string>
     <string name="settings_button_text">การตั้งค่าหน้าโฮม</string>
@@ -69,7 +69,7 @@
     <string name="title_change_settings">เปลี่ยนการตั้งค่า</string>
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout ผู้ช่วย AI
 
     -->
     <string name="others_category_label">อื่นๆ</string>
@@ -114,7 +114,7 @@
     <string name="folders_filter_duplicates">Only show unique apps</string>
     <string name="my_folder_label">My folder</string>
     <!-- A11y description -->
-    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, Lawnchair uses the performGlobalAction Accessibility service.</string>
+    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, ผู้ช่วย AI requires accessibility access.\n\nผู้ช่วย AI doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. ผู้ช่วย AI discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, ผู้ช่วย AI uses the performGlobalAction Accessibility service.</string>
     <string name="x_with_y_count">%1$s (%2$d)</string>
     <string name="x_by_y">%1$d x %2$d</string>
     <string name="x_and_y">%1$s &amp; %2$s</string>
@@ -143,7 +143,7 @@
     <string name="quickstep_description">ล้างปุ่มทั้งหมด, รัศมีมุม</string>
     <string name="about_label">เกี่ยวกับ</string>
     <string name="app_info_drop_target_label">ข้อมูลแอป</string>
-    <string name="debug_restart_launcher">เริ่มต้น Lawnchair ใหม่</string>
+    <string name="debug_restart_launcher">เริ่มต้น ผู้ช่วย AI ใหม่</string>
     <string name="experimental_features_label">ฟีเจอร์ทดลอง</string>
     <!-- Experimental features -->
     <string name="font_picker_label">การปรับแต่งแบบอักษร</string>
@@ -171,7 +171,7 @@
     Notifications
 
     -->
-    <string name="set_default_launcher_tip">หากต้องการเข้าถึงทางลัดและคุณสมบัติเพิ่มเติม ให้ตั้งค่า Lawnchair เป็นแอปหน้าแรกเริ่มต้น</string>
+    <string name="set_default_launcher_tip">หากต้องการเข้าถึงทางลัดและคุณสมบัติเพิ่มเติม ให้ตั้งค่า ผู้ช่วย AI เป็นแอปหน้าแรกเริ่มต้น</string>
     <string name="notification_dots">จุดแสดงการแจ้งเตือน</string>
     <string name="show_notification_count">แสดงตัวเลขจากการแจ้งเตือน</string>
     <string name="notification_dots_color">สีจุดการแจ้งเตือน</string>
@@ -344,7 +344,7 @@
     <string name="event_provider_missing_notification_dots">หากต้องการใช้ <xliff:g example="My Provider" id="providerName">%1$s</xliff:g> ให้เปิดจุดแสดงการแจ้งเตือน</string>
     <!-- Toggle button for enabling Smartspace -->
     <string name="smartspace_widget_toggle_label">แสดงบนหน้าจอหลัก</string>
-    <string name="smartspace_widget_toggle_description">สามารถเพิ่มข้อมูลโดยย่อในหน้าหลักได้ด้วยตนเองโดยวางวิดเจ็ต Lawnchair</string>
+    <string name="smartspace_widget_toggle_description">สามารถเพิ่มข้อมูลโดยย่อในหน้าหลักได้ด้วยตนเองโดยวางวิดเจ็ต ผู้ช่วย AI</string>
     <!-- List of available providers -->
     <string name="smartspace_mode_label">ผู้ให้บริการข้อมูลโดยย่อ</string>
     <string name="smartspace_mode_google">Google</string>
@@ -415,18 +415,18 @@
     <string name="gesture_handler_open_assistant">Open assistant</string>
     <string name="pick_app_for_gesture">เลือกแอป</string>
     <string name="dt2s_admin_hint_title">จำเป็นต้องมีสิทธิ์ผู้ดูแลอุปกรณ์</string>
-    <string name="dt2s_admin_hint">หากต้องการแตะสองครั้งเพี่อปิดจอ ให้ตั้งค่า Lawnchair เป็นแอปผู้ดูแลอุปกรณ์ แตะเปิดการตั้งค่า จากนั้นแตะ “เปิดใช้งานแอปผู้ดูแลระบบอุปกรณ์นี้”</string>
+    <string name="dt2s_admin_hint">หากต้องการแตะสองครั้งเพี่อปิดจอ ให้ตั้งค่า ผู้ช่วย AI เป็นแอปผู้ดูแลอุปกรณ์ แตะเปิดการตั้งค่า จากนั้นแตะ “เปิดใช้งานแอปผู้ดูแลระบบอุปกรณ์นี้”</string>
     <string name="dt2s_admin_warning">แตะสองครั้งเพื่อเข้าสู่โหมดสลีป หน้าจอจะถูกปิด</string>
     <string name="d2ts_recents_a11y_hint_title">เปิดบริการการช่วยการเข้าถึง</string>
-    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the ผู้ช่วย AI accessibility service. Tap \"Open settings\", select \"ผู้ช่วย AI\" and turn on \"Use ผู้ช่วย AI.\"\n\nผู้ช่วย AI uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, ผู้ช่วย AI is not configured for that functionality and receives no events.</string>
     <string name="dt2s_recents_warning_open_settings">เปิดการตั้งค่า</string>
-    <string name="recents_a11y_hint">To use Open Recents screen, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="recents_a11y_hint">To use Open Recents screen, turn on the ผู้ช่วย AI accessibility service. Tap \"Open settings\", select \"ผู้ช่วย AI\" and turn on \"Use ผู้ช่วย AI.\"\n\nผู้ช่วย AI uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, ผู้ช่วย AI is not configured for that functionality and receives no events.</string>
     <!--
 
     Bug reporting
 
     -->
-    <string name="lawnchair_bug_report">รายงานข้อผิดพลาดให้กับ Lawnchair</string>
+    <string name="lawnchair_bug_report">รายงานข้อผิดพลาดให้กับ ผู้ช่วย AI</string>
     <string name="crash_report_notif_title">%1$s ทำงานผิดพลาด</string>
     <string name="action_upload_crash_report">อัปโหลด Log ข้อผิดพลาด</string>
     <string name="action_upload_error">อัปโหลดไม่สำเร็จ</string>
@@ -519,7 +519,7 @@
     <!-- Search providers -->
     <string name="search_provider_app_search">ค้นหาแอป</string>
     <string name="search_provider_custom">ปรับแต่ง</string>
-    <string name="search_provider_sponsored_description">%1$s และ Lawnchair มีข้อตกลงแบ่งรายได้ร่วมกัน\n\nการค้นหาด้วย %1$s ช่วยสนับสนุน Lawnchair</string>
+    <string name="search_provider_sponsored_description">%1$s และ ผู้ช่วย AI มีข้อตกลงแบ่งรายได้ร่วมกัน\n\nการค้นหาด้วย %1$s ช่วยสนับสนุน ผู้ช่วย AI</string>
     <string name="app_label">แอป</string>
     <string name="website_label">เว็บไซต์</string>
     <string name="qsb_search_provider_app_required">จำเป็นต้องมีแอป</string>
@@ -551,7 +551,7 @@
     <string name="max_folder_columns">จำนวนคอลัมน์สูงสุดของโฟลเดอร์</string>
     <string name="max_folder_rows">จำนวนแถวสูงสุดของโฟลเดอร์</string>
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">These settings will be ignored as Lawnchair isn\'t set as the Recents screen provider</string>
+    <string name="quickswitch_ignored_warning">These settings will be ignored as ผู้ช่วย AI isn\'t set as the Recents screen provider</string>
     <string name="quickstep_incompatible">ระบบไม่สามารถเข้ากันได้</string>
     <string name="quickstep_incompatible_description">อุปกรณ์ของคุณได้รับการกำหนดค่าให้มีรูปแบบลายเส้นของระบบ (เรียกว่า Quickstep) ซึ่งให้บริการโดย %1$s แต่ %1$s เวอร์ชันนี้ไม่สามารถทำงานร่วมกับ Android เวอร์ชันของคุณได้ หากต้องการใช้อุปกรณ์ของคุณต่อไป โปรดถอนการติดตั้งการอัปเดต %1$s หรือปิดใช้งาน %1$s ในการตั้งค่า</string>
     <string name="translucent_background">พื้นหลังโปร่งแสง</string>

--- a/lawnchair/res/values-th/strings.xml
+++ b/lawnchair/res/values-th/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, ผู้ช่วย AI
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-tl/strings.xml
+++ b/lawnchair/res/values-tl/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, Katulong ng AI
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-tr-rTR/strings.xml
+++ b/lawnchair/res/values-tr-rTR/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI asistanı
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@
     <string name="time_weeks_ago">%dhft</string>
     <string name="time_months_ago">%day</string>
     <string name="time_years_ago">%dyıl</string>
-    <string name="managed_by_lawnchair">Lawnchair tarafından yönetilmektedir</string>
+    <string name="managed_by_lawnchair">AI asistanı tarafından yönetilmektedir</string>
     <!-- When mentioning settings UI -->
     <string name="smartspace_preferences">Tercihler</string>
     <string name="settings_button_text">Ana ekran ayarları</string>
@@ -69,7 +69,7 @@
     <string name="title_change_settings">Ayarları değiştir</string>
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout AI asistanı
 
     -->
     <string name="others_category_label">Diğerleri</string>
@@ -114,7 +114,7 @@
     <string name="folders_filter_duplicates">Sadece farklı uygulamaları göster</string>
     <string name="my_folder_label">Benim klasörüm</string>
     <!-- A11y description -->
-    <string name="accessibility_service_description">Belirli eylemleri (örneğin telefonunuzu kilitlemek) bir hareketle gerçekleştirebilmek için, Lawnchair erişilebilirlik iznine ihtiyaç duyar.\n\nLawnchair hiçbir kullanıcı etkinliğini izlemez; ancak tüm erişilebilirlik servislerinde bu ayrıcalık gereklidir. Lawnchair, sistem tarafından gönderilen tüm olayları yok sayar.\n\nTelefonunuzu kilitlemek veya Son uygulamalar ekranını açmak için Lawnchair, performGlobalAction Erişilebilirlik servisini kullanır.</string>
+    <string name="accessibility_service_description">Belirli eylemleri (örneğin telefonunuzu kilitlemek) bir hareketle gerçekleştirebilmek için, AI asistanı erişilebilirlik iznine ihtiyaç duyar.\n\nAI asistanı hiçbir kullanıcı etkinliğini izlemez; ancak tüm erişilebilirlik servislerinde bu ayrıcalık gereklidir. AI asistanı, sistem tarafından gönderilen tüm olayları yok sayar.\n\nTelefonunuzu kilitlemek veya Son uygulamalar ekranını açmak için AI asistanı, performGlobalAction Erişilebilirlik servisini kullanır.</string>
     <string name="x_with_y_count">%1$s (%2$d)</string>
     <string name="x_by_y">%1$d x %2$d</string>
     <string name="x_and_y">%1$s &amp; %2$s</string>
@@ -143,7 +143,7 @@
     <string name="quickstep_description">Tümünü Temizle tuşu, köşe yarıçapı</string>
     <string name="about_label">Hakkında</string>
     <string name="app_info_drop_target_label">Uygulama Hakkında</string>
-    <string name="debug_restart_launcher">Lawnchair\'i Yeniden Başlat</string>
+    <string name="debug_restart_launcher">AI asistanı\'i Yeniden Başlat</string>
     <string name="experimental_features_label">Deneyimsel özellikler</string>
     <!-- Experimental features -->
     <string name="font_picker_label">Yazı tipi özelleştirmesi</string>
@@ -171,7 +171,7 @@
     Notifications
 
     -->
-    <string name="set_default_launcher_tip">Kısayollar ve ek özellikler için Lawnchair\'ı varsayılan başlatıcınız yapın</string>
+    <string name="set_default_launcher_tip">Kısayollar ve ek özellikler için AI asistanı\'ı varsayılan başlatıcınız yapın</string>
     <string name="notification_dots">Bildirim rozetleri</string>
     <string name="show_notification_count">Bildirim sayımı göster</string>
     <string name="notification_dots_color">Bildirim noktası rengi</string>
@@ -344,7 +344,7 @@
     <string name="event_provider_missing_notification_dots"><xliff:g example="My Provider" id="providerName">%1$s</xliff:g> kullanmak için, bildirim noktalarını aç.</string>
     <!-- Toggle button for enabling Smartspace -->
     <string name="smartspace_widget_toggle_label">Ana ekranda göster</string>
-    <string name="smartspace_widget_toggle_description">Bir Bakışta widget\'i ana ekrana manuel olarak Lawnchair widget\'i kullanılarak eklenebilir</string>
+    <string name="smartspace_widget_toggle_description">Bir Bakışta widget\'i ana ekrana manuel olarak AI asistanı widget\'i kullanılarak eklenebilir</string>
     <!-- List of available providers -->
     <string name="smartspace_mode_label">Bir Bakışta sağlayıcı</string>
     <string name="smartspace_mode_google">Google</string>
@@ -415,18 +415,18 @@
     <string name="gesture_handler_open_assistant">Asistanı aç</string>
     <string name="pick_app_for_gesture">Uygulama seç</string>
     <string name="dt2s_admin_hint_title">Yönetici izinleri gerekli</string>
-    <string name="dt2s_admin_hint">Ekranı Kapatmak İçin Çift Dokunun\'u kullanmak için Lawnchair\'i bir cihaz yöneticisi uygulaması olarak ayarlayın. Ayarları Aç\'a tıklayın, ardından \"Bu cihaz yöneticisi uygulamasını aktif et\" seçeneğine tıklayın</string>
+    <string name="dt2s_admin_hint">Ekranı Kapatmak İçin Çift Dokunun\'u kullanmak için AI asistanı\'i bir cihaz yöneticisi uygulaması olarak ayarlayın. Ayarları Aç\'a tıklayın, ardından \"Bu cihaz yöneticisi uygulamasını aktif et\" seçeneğine tıklayın</string>
     <string name="dt2s_admin_warning">Ekranı Kapatmak İçin Çift Dokunun kapatılacaktır.</string>
     <string name="d2ts_recents_a11y_hint_title">Erişilebilirlik hizmetini açın</string>
-    <string name="dt2s_a11y_hint">Çift Dokunarak Uyutma özelliğini kullanmak için Lawnchair erişilebilirlik servisini açın. \"Ayarları aç\" seçeneğine dokunun, \"Lawnchair\"i seçin ve \"Etkinleştir\" seçeneğini aktif edin.\n\nLawnchair, bu işlemi gerçekleştirmek için Erişilebilirlik’in performGlobalAction yöntemini kullanır. Bu, diğer uygulamaları izlemeye olanak tanıyan hassas bir izindir. Ancak, Lawnchair bu işlevsellik için yapılandırılmamıştır ve herhangi bir etkinlik almaz.</string>
+    <string name="dt2s_a11y_hint">Çift Dokunarak Uyutma özelliğini kullanmak için AI asistanı erişilebilirlik servisini açın. \"Ayarları aç\" seçeneğine dokunun, \"AI asistanı\"i seçin ve \"Etkinleştir\" seçeneğini aktif edin.\n\nAI asistanı, bu işlemi gerçekleştirmek için Erişilebilirlik’in performGlobalAction yöntemini kullanır. Bu, diğer uygulamaları izlemeye olanak tanıyan hassas bir izindir. Ancak, AI asistanı bu işlevsellik için yapılandırılmamıştır ve herhangi bir etkinlik almaz.</string>
     <string name="dt2s_recents_warning_open_settings">Ayarları aç</string>
-    <string name="recents_a11y_hint">Son Kullanılanlar özelliğini kullanmak için Lawnchair erişilebilirlik hizmetini açın. \"Ayarları aç\"a dokunun, \"Lawnchair\"i seçin ve etkinleştirin.\n\nLawnchair, bu işlemi gerçekleştirmek için Accessibility\'nin performGlobalAction yöntemini kullanır. Bu, diğer uygulamaları izlemeye olanak tanıyan hassas bir izindir. Ancak Lawnchair, bu işlev için yapılandırılmamıştır ve herhangi bir olay almaz.</string>
+    <string name="recents_a11y_hint">Son Kullanılanlar özelliğini kullanmak için AI asistanı erişilebilirlik hizmetini açın. \"Ayarları aç\"a dokunun, \"AI asistanı\"i seçin ve etkinleştirin.\n\nAI asistanı, bu işlemi gerçekleştirmek için Accessibility\'nin performGlobalAction yöntemini kullanır. Bu, diğer uygulamaları izlemeye olanak tanıyan hassas bir izindir. Ancak AI asistanı, bu işlev için yapılandırılmamıştır ve herhangi bir olay almaz.</string>
     <!--
 
     Bug reporting
 
     -->
-    <string name="lawnchair_bug_report">Lawnchair Hata Bildirme</string>
+    <string name="lawnchair_bug_report">AI asistanı Hata Bildirme</string>
     <string name="crash_report_notif_title">%1$s çalışmayı Durdurdu</string>
     <string name="action_upload_crash_report">Çökme günlüğünü yükle</string>
     <string name="action_upload_error">Yükleme Başarısız</string>
@@ -519,7 +519,7 @@
     <!-- Search providers -->
     <string name="search_provider_app_search">Uygulama araması</string>
     <string name="search_provider_custom">Özel</string>
-    <string name="search_provider_sponsored_description">Lawnchar\'ın %1$s ile sponsorluk anlaşması vardır\n\n %1$s ile arama yaparak Lawnchair\'a katkı sağlayabilirsiniz.</string>
+    <string name="search_provider_sponsored_description">Lawnchar\'ın %1$s ile sponsorluk anlaşması vardır\n\n %1$s ile arama yaparak AI asistanı\'a katkı sağlayabilirsiniz.</string>
     <string name="app_label">Uygulama</string>
     <string name="website_label">Web sitesi</string>
     <string name="qsb_search_provider_app_required">Uygulama gerekli</string>
@@ -552,7 +552,7 @@
     <string name="max_folder_columns">Maksimum klasör sütunları</string>
     <string name="max_folder_rows">Maksimum klasör satırı</string>
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">Bu ayarlar Lawnchair Son Kullanılanlar sağlayıcısı olmadığı sürece yok sayılacak</string>
+    <string name="quickswitch_ignored_warning">Bu ayarlar AI asistanı Son Kullanılanlar sağlayıcısı olmadığı sürece yok sayılacak</string>
     <string name="quickstep_incompatible">Uyumsuz sistem entegrasyonu</string>
     <string name="quickstep_incompatible_description">Cihazınız %1$s tarafından sağlanan sistem hareketlerine (Quickstep olarak bilinir) sahip olacak şekilde yapılandırılmıştır, ancak %1$s\'nin bu sürümü Android sürümünüzle uyumlu değildir. Cihazınızı kullanmaya devam etmek için lütfen %1$s güncellemelerini kaldırın veya sistem hareketi sağlayıcısı olarak %1$s\'ı devre dışı bırakın.</string>
     <string name="translucent_background">Yarı saydam arka plan</string>

--- a/lawnchair/res/values-tr/strings.xml
+++ b/lawnchair/res/values-tr/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI asistanı
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-uk-rUA/strings.xml
+++ b/lawnchair/res/values-uk-rUA/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI Assistant
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@
     <string name="time_weeks_ago">%dw</string>
     <string name="time_months_ago">%dmo</string>
     <string name="time_years_ago">%dy</string>
-    <string name="managed_by_lawnchair">Керується Lawnchair</string>
+    <string name="managed_by_lawnchair">Керується AI Assistant</string>
     <!-- When mentioning settings UI -->
     <string name="smartspace_preferences">Налаштування</string>
     <string name="settings_button_text">Налаштування головного екрана</string>
@@ -69,7 +69,7 @@
     <string name="title_change_settings">Змінити налаштування</string>
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout AI Assistant
 
     -->
     <string name="others_category_label">Інші</string>
@@ -114,7 +114,7 @@
     <string name="folders_filter_duplicates">Only show unique apps</string>
     <string name="my_folder_label">Моя папка</string>
     <!-- A11y description -->
-    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, Lawnchair uses the performGlobalAction Accessibility service.</string>
+    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, AI Assistant requires accessibility access.\n\nAI Assistant doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. AI Assistant discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, AI Assistant uses the performGlobalAction Accessibility service.</string>
     <string name="x_with_y_count">%1$s (%2$d)</string>
     <string name="x_by_y">%1$d на %2$d</string>
     <string name="x_and_y">%1$s &amp; %2$s</string>
@@ -143,7 +143,7 @@
     <string name="quickstep_description">Кнопка \"Очистити все\", радіус заокруглення кутів</string>
     <string name="about_label">Про додаток</string>
     <string name="app_info_drop_target_label">Про застосунок</string>
-    <string name="debug_restart_launcher">Перезавантажте Lawnchair</string>
+    <string name="debug_restart_launcher">Перезавантажте AI Assistant</string>
     <string name="experimental_features_label">Експериментальні можливості</string>
     <!-- Experimental features -->
     <string name="font_picker_label">Налаштування шрифту</string>
@@ -171,7 +171,7 @@
     Notifications
 
     -->
-    <string name="set_default_launcher_tip">Щоб отримати доступ до ярликів і додаткових функцій, встановіть Lawnchair як лаунчер за замовчуванням</string>
+    <string name="set_default_launcher_tip">Щоб отримати доступ до ярликів і додаткових функцій, встановіть AI Assistant як лаунчер за замовчуванням</string>
     <string name="notification_dots">Позначки сповіщень</string>
     <string name="show_notification_count">Показувати лічильник сповіщень</string>
     <string name="notification_dots_color">Колір позначки сповіщень</string>
@@ -344,7 +344,7 @@
     <string name="event_provider_missing_notification_dots">Щоб використовувати <xliff:g example="My Provider" id="providerName">%1$s</xliff:g>, увімкніть Позначки Сповіщень.</string>
     <!-- Toggle button for enabling Smartspace -->
     <string name="smartspace_widget_toggle_label">Показувати на головному екрані</string>
-    <string name="smartspace_widget_toggle_description">Віджет At a Glance можна додати на головний екран вручну, помістивши віджет \"Lawnchair\"</string>
+    <string name="smartspace_widget_toggle_description">Віджет At a Glance можна додати на головний екран вручну, помістивши віджет \"AI Assistant\"</string>
     <!-- List of available providers -->
     <string name="smartspace_mode_label">Постачальник At a Glance</string>
     <string name="smartspace_mode_google">Google</string>
@@ -415,18 +415,18 @@
     <string name="gesture_handler_open_assistant">Open assistant</string>
     <string name="pick_app_for_gesture">Обрати додаток</string>
     <string name="dt2s_admin_hint_title">Потрібен дозвіл Адміністратора</string>
-    <string name="dt2s_admin_hint">Щоб використовувати «Подвійний Дотик для Переходу в Режим Сну», надайте Lawnchair дозвіл адміністратора. Натисніть «Відкрити Налаштування», потім натисніть «Активувати цю програму адміністрування пристрою.»</string>
+    <string name="dt2s_admin_hint">Щоб використовувати «Подвійний Дотик для Переходу в Режим Сну», надайте AI Assistant дозвіл адміністратора. Натисніть «Відкрити Налаштування», потім натисніть «Активувати цю програму адміністрування пристрою.»</string>
     <string name="dt2s_admin_warning">«Подвійне Натискання в Сплячий Режим» буде відключено.</string>
     <string name="d2ts_recents_a11y_hint_title">Увімкнути службу Спеціальних Можливостей</string>
-    <string name="dt2s_a11y_hint">Щоб використовувати \"Подвійний Дотик для Переходу в Режим Сну\", увімкніть службу доступності Lawnchair. Натисніть \"Відкрити налаштування\", виберіть \"Lawnchair\" і увімкніть \"Використовувати Lawnchair\".\n\nLawnchair використовує метод доступності `performGlobalAction` для виконання цієї дії. Це чутливий дозвіл, який дозволяє контролювати інші програми. Втім, Lawnchair не налаштований на цю можливість і не отримує жодних подій.</string>
+    <string name="dt2s_a11y_hint">Щоб використовувати \"Подвійний Дотик для Переходу в Режим Сну\", увімкніть службу доступності AI Assistant. Натисніть \"Відкрити налаштування\", виберіть \"AI Assistant\" і увімкніть \"Використовувати AI Assistant\".\n\nAI Assistant використовує метод доступності `performGlobalAction` для виконання цієї дії. Це чутливий дозвіл, який дозволяє контролювати інші програми. Втім, AI Assistant не налаштований на цю можливість і не отримує жодних подій.</string>
     <string name="dt2s_recents_warning_open_settings">Відкрити Налаштування</string>
-    <string name="recents_a11y_hint">To use Open Recents screen, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="recents_a11y_hint">To use Open Recents screen, turn on the AI Assistant accessibility service. Tap \"Open settings\", select \"AI Assistant\" and turn on \"Use AI Assistant.\"\n\nAI Assistant uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, AI Assistant is not configured for that functionality and receives no events.</string>
     <!--
 
     Bug reporting
 
     -->
-    <string name="lawnchair_bug_report">Звіт про помилку Lawnchair</string>
+    <string name="lawnchair_bug_report">Звіт про помилку AI Assistant</string>
     <string name="crash_report_notif_title">%1$s завершив роботу</string>
     <string name="action_upload_crash_report">Завантажити журнал збоїв</string>
     <string name="action_upload_error">Помилка завантаження</string>
@@ -519,7 +519,7 @@
     <!-- Search providers -->
     <string name="search_provider_app_search">Пошук додатків</string>
     <string name="search_provider_custom">Користувацькі налаштування</string>
-    <string name="search_provider_sponsored_description">%1$s та Lawnchair уклали партнерську угоду.\n\nПошук через %1$s допомагає підтримувати Lawnchair.</string>
+    <string name="search_provider_sponsored_description">%1$s та AI Assistant уклали партнерську угоду.\n\nПошук через %1$s допомагає підтримувати AI Assistant.</string>
     <string name="app_label">Застосунок</string>
     <string name="website_label">Вебсайт</string>
     <string name="qsb_search_provider_app_required">Необхідний додаток</string>
@@ -554,7 +554,7 @@
     <string name="max_folder_columns">Максимальна кількість стовпців у теці</string>
     <string name="max_folder_rows">Максимальна кількість рядків у теці</string>
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">These settings will be ignored as Lawnchair isn\'t set as the Recents screen provider</string>
+    <string name="quickswitch_ignored_warning">These settings will be ignored as AI Assistant isn\'t set as the Recents screen provider</string>
     <string name="quickstep_incompatible">Несумісна системна інтеграція</string>
     <string name="quickstep_incompatible_description">Ваш пристрій налаштовано на використання системних жестів (відомих як Quickstep) від %1$s, але ця версія %1$s несумісна з вашою версією Android. Щоб продовжити користуватися пристроєм, видаліть оновлення %1$s або вимкніть %1$s як постачальника системних жестів.</string>
     <string name="translucent_background">Напівпрозорий фон</string>

--- a/lawnchair/res/values-uk/strings.xml
+++ b/lawnchair/res/values-uk/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI Assistant
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-ur-rIN/strings.xml
+++ b/lawnchair/res/values-ur-rIN/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI اسسٹنٹ
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -69,7 +69,7 @@
     <string name="title_change_settings">ترتیبات کو تبدیل کریں۔</string>
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout AI اسسٹنٹ
 
     -->
     <string name="others_category_label">دوسرے</string>
@@ -114,7 +114,7 @@
     <string name="folders_filter_duplicates">صرف منفرد ایپس دکھائیں۔</string>
     <string name="my_folder_label">میرا فولڈر</string>
     <!-- A11y description -->
-    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, Lawnchair uses the performGlobalAction Accessibility service.</string>
+    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, AI اسسٹنٹ requires accessibility access.\n\nAI اسسٹنٹ doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. AI اسسٹنٹ discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, AI اسسٹنٹ uses the performGlobalAction Accessibility service.</string>
     <string name="x_with_y_count">%1$s (%2$d)</string>
     <string name="x_by_y">%1$d x %2$d</string>
     <string name="x_and_y">%1$s &amp; %2$s</string>
@@ -415,12 +415,12 @@
     <string name="gesture_handler_open_assistant">اسسٹنٹ کھولیں۔</string>
     <string name="pick_app_for_gesture">ایپ چنیں۔</string>
     <string name="dt2s_admin_hint_title">ایڈمن کی اجازت درکار ہے۔</string>
-    <string name="dt2s_admin_hint">سونے کے لیے ڈبل تھپتھپائیں استعمال کرنے کے لیے، Lawnchair کو بطور ڈیوائس ایڈمن ایپ سیٹ کریں۔ \"کھولیں ترتیبات\" کو تھپتھپائیں، پھر \"اس ڈیوائس ایڈمن ایپ کو چالو کریں\" پر ٹیپ کریں۔</string>
+    <string name="dt2s_admin_hint">سونے کے لیے ڈبل تھپتھپائیں استعمال کرنے کے لیے، AI اسسٹنٹ کو بطور ڈیوائس ایڈمن ایپ سیٹ کریں۔ \"کھولیں ترتیبات\" کو تھپتھپائیں، پھر \"اس ڈیوائس ایڈمن ایپ کو چالو کریں\" پر ٹیپ کریں۔</string>
     <string name="dt2s_admin_warning">دو بار دوبا کر سولانا غیر فعال ہو جائے گا۔.</string>
     <string name="d2ts_recents_a11y_hint_title">ایکسیسبیلٹی سروس کو آن کریں۔</string>
-    <string name="dt2s_a11y_hint">سونے کے لیے ڈبل تھپتھپائیں استعمال کرنے کے لیے، لانچ چیئر تک رسائی کی خدمت کو آن کریں۔ \"اوپن سیٹنگز\" کو تھپتھپائیں، \"لان چیئر\" کو منتخب کریں اور \"لان چیئر کا استعمال کریں\" کو آن کریں۔\n\nلان چیئر اس کارروائی کو انجام دینے کے لیے ایکسیسبیلٹی کا `پرفارم گلوبل ایکشن` طریقہ استعمال کرتی ہے۔ یہ ایک حساس اجازت ہے جو دوسری ایپس کی نگرانی کرنے کی اجازت دیتی ہے۔ تاہم، Lawnchair کو اس فعالیت کے لیے ترتیب نہیں دیا گیا ہے اور اسے کوئی ایونٹ نہیں ملتا ہے۔</string>
+    <string name="dt2s_a11y_hint">سونے کے لیے ڈبل تھپتھپائیں استعمال کرنے کے لیے، لانچ چیئر تک رسائی کی خدمت کو آن کریں۔ \"اوپن سیٹنگز\" کو تھپتھپائیں، \"لان چیئر\" کو منتخب کریں اور \"لان چیئر کا استعمال کریں\" کو آن کریں۔\n\nلان چیئر اس کارروائی کو انجام دینے کے لیے ایکسیسبیلٹی کا `پرفارم گلوبل ایکشن` طریقہ استعمال کرتی ہے۔ یہ ایک حساس اجازت ہے جو دوسری ایپس کی نگرانی کرنے کی اجازت دیتی ہے۔ تاہم، AI اسسٹنٹ کو اس فعالیت کے لیے ترتیب نہیں دیا گیا ہے اور اسے کوئی ایونٹ نہیں ملتا ہے۔</string>
     <string name="dt2s_recents_warning_open_settings">ترتیبات کھولیں۔</string>
-    <string name="recents_a11y_hint">To use Open Recents screen, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="recents_a11y_hint">To use Open Recents screen, turn on the AI اسسٹنٹ accessibility service. Tap \"Open settings\", select \"AI اسسٹنٹ\" and turn on \"Use AI اسسٹنٹ.\"\n\nAI اسسٹنٹ uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, AI اسسٹنٹ is not configured for that functionality and receives no events.</string>
     <!--
 
     Bug reporting
@@ -519,7 +519,7 @@
     <!-- Search providers -->
     <string name="search_provider_app_search">ایپ کی تلاش</string>
     <string name="search_provider_custom">حسب ضرورت</string>
-    <string name="search_provider_sponsored_description">%1$s اور Lawnchair کا ریونیو شیئر کا معاہدہ ہے۔\n\n%1$s کے ساتھ تلاش کرنے سے Lawnchair کو سپورٹ کرنے میں مدد ملتی ہے۔</string>
+    <string name="search_provider_sponsored_description">%1$s اور AI اسسٹنٹ کا ریونیو شیئر کا معاہدہ ہے۔\n\n%1$s کے ساتھ تلاش کرنے سے AI اسسٹنٹ کو سپورٹ کرنے میں مدد ملتی ہے۔</string>
     <string name="app_label">ایپ</string>
     <string name="website_label">ویب سائٹ</string>
     <string name="qsb_search_provider_app_required">ایپ درکار ہے۔</string>
@@ -552,7 +552,7 @@
     <string name="max_folder_columns">زیادہ سے زیادہ فولڈر کالم</string>
     <string name="max_folder_rows">فولڈر کی زیادہ سے زیادہ قطاریں۔</string>
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">These settings will be ignored as Lawnchair isn\'t set as the Recents screen provider</string>
+    <string name="quickswitch_ignored_warning">These settings will be ignored as AI اسسٹنٹ isn\'t set as the Recents screen provider</string>
     <string name="quickstep_incompatible">غیر مطابقت پذیر نظام کا انضمام</string>
     <string name="quickstep_incompatible_description">آپ کے آلے کو %1$s کے ذریعہ فراہم کردہ سسٹم اشاروں (جسے Quickstep کہا جاتا ہے) کے لیے ترتیب دیا گیا ہے، لیکن %1$s کا یہ ورژن آپ کے Android ورژن کے ساتھ مطابقت نہیں رکھتا ہے۔ اپنے آلے کا استعمال جاری رکھنے کے لیے، براہ کرم %1$s اپ ڈیٹس کو اَن انسٹال کریں یا %1$s کو سسٹم اشارہ فراہم کنندہ کے طور پر غیر فعال کریں۔</string>
     <string name="translucent_background">شفاف پس منظر</string>

--- a/lawnchair/res/values-ur-rPK/strings.xml
+++ b/lawnchair/res/values-ur-rPK/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI اسسٹنٹ
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -69,7 +69,7 @@
     <string name="title_change_settings">ترتیبات کو تبدیل کریں۔</string>
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout AI اسسٹنٹ
 
     -->
     <string name="others_category_label">دوسرے</string>
@@ -114,7 +114,7 @@
     <string name="folders_filter_duplicates">صرف منفرد ایپس دکھائیں۔</string>
     <string name="my_folder_label">میرا فولڈر</string>
     <!-- A11y description -->
-    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, Lawnchair uses the performGlobalAction Accessibility service.</string>
+    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, AI اسسٹنٹ requires accessibility access.\n\nAI اسسٹنٹ doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. AI اسسٹنٹ discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, AI اسسٹنٹ uses the performGlobalAction Accessibility service.</string>
     <string name="x_with_y_count">%1$s (%2$d)</string>
     <string name="x_by_y">%1$d x %2$d</string>
     <string name="x_and_y">%1$s &amp; %2$s</string>
@@ -415,12 +415,12 @@
     <string name="gesture_handler_open_assistant">اسسٹنٹ کھولیں۔</string>
     <string name="pick_app_for_gesture">ایپ چنیں۔</string>
     <string name="dt2s_admin_hint_title">ایڈمن کی اجازت درکار ہے۔</string>
-    <string name="dt2s_admin_hint">سونے کے لیے ڈبل تھپتھپائیں استعمال کرنے کے لیے، Lawnchair کو بطور ڈیوائس ایڈمن ایپ سیٹ کریں۔ \"کھولیں ترتیبات\" کو تھپتھپائیں، پھر \"اس ڈیوائس ایڈمن ایپ کو چالو کریں\" پر ٹیپ کریں۔</string>
+    <string name="dt2s_admin_hint">سونے کے لیے ڈبل تھپتھپائیں استعمال کرنے کے لیے، AI اسسٹنٹ کو بطور ڈیوائس ایڈمن ایپ سیٹ کریں۔ \"کھولیں ترتیبات\" کو تھپتھپائیں، پھر \"اس ڈیوائس ایڈمن ایپ کو چالو کریں\" پر ٹیپ کریں۔</string>
     <string name="dt2s_admin_warning">دو بار دوبا کر سولانا غیر فعال ہو جائے گا۔.</string>
     <string name="d2ts_recents_a11y_hint_title">ایکسیسبیلٹی سروس کو آن کریں۔</string>
-    <string name="dt2s_a11y_hint">سونے کے لیے ڈبل تھپتھپائیں استعمال کرنے کے لیے، لانچ چیئر تک رسائی کی خدمت کو آن کریں۔ \"اوپن سیٹنگز\" کو تھپتھپائیں، \"لان چیئر\" کو منتخب کریں اور \"لان چیئر کا استعمال کریں\" کو آن کریں۔\n\nلان چیئر اس کارروائی کو انجام دینے کے لیے ایکسیسبیلٹی کا `پرفارم گلوبل ایکشن` طریقہ استعمال کرتی ہے۔ یہ ایک حساس اجازت ہے جو دوسری ایپس کی نگرانی کرنے کی اجازت دیتی ہے۔ تاہم، Lawnchair کو اس فعالیت کے لیے ترتیب نہیں دیا گیا ہے اور اسے کوئی ایونٹ نہیں ملتا ہے۔</string>
+    <string name="dt2s_a11y_hint">سونے کے لیے ڈبل تھپتھپائیں استعمال کرنے کے لیے، لانچ چیئر تک رسائی کی خدمت کو آن کریں۔ \"اوپن سیٹنگز\" کو تھپتھپائیں، \"لان چیئر\" کو منتخب کریں اور \"لان چیئر کا استعمال کریں\" کو آن کریں۔\n\nلان چیئر اس کارروائی کو انجام دینے کے لیے ایکسیسبیلٹی کا `پرفارم گلوبل ایکشن` طریقہ استعمال کرتی ہے۔ یہ ایک حساس اجازت ہے جو دوسری ایپس کی نگرانی کرنے کی اجازت دیتی ہے۔ تاہم، AI اسسٹنٹ کو اس فعالیت کے لیے ترتیب نہیں دیا گیا ہے اور اسے کوئی ایونٹ نہیں ملتا ہے۔</string>
     <string name="dt2s_recents_warning_open_settings">ترتیبات کھولیں۔</string>
-    <string name="recents_a11y_hint">To use Open Recents screen, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="recents_a11y_hint">To use Open Recents screen, turn on the AI اسسٹنٹ accessibility service. Tap \"Open settings\", select \"AI اسسٹنٹ\" and turn on \"Use AI اسسٹنٹ.\"\n\nAI اسسٹنٹ uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, AI اسسٹنٹ is not configured for that functionality and receives no events.</string>
     <!--
 
     Bug reporting
@@ -519,7 +519,7 @@
     <!-- Search providers -->
     <string name="search_provider_app_search">ایپ کی تلاش</string>
     <string name="search_provider_custom">حسب ضرورت</string>
-    <string name="search_provider_sponsored_description">%1$s اور Lawnchair کا ریونیو شیئر کا معاہدہ ہے۔\n\n%1$s کے ساتھ تلاش کرنے سے Lawnchair کو سپورٹ کرنے میں مدد ملتی ہے۔</string>
+    <string name="search_provider_sponsored_description">%1$s اور AI اسسٹنٹ کا ریونیو شیئر کا معاہدہ ہے۔\n\n%1$s کے ساتھ تلاش کرنے سے AI اسسٹنٹ کو سپورٹ کرنے میں مدد ملتی ہے۔</string>
     <string name="app_label">ایپ</string>
     <string name="website_label">ویب سائٹ</string>
     <string name="qsb_search_provider_app_required">ایپ درکار ہے۔</string>
@@ -552,7 +552,7 @@
     <string name="max_folder_columns">زیادہ سے زیادہ فولڈر کالم</string>
     <string name="max_folder_rows">فولڈر کی زیادہ سے زیادہ قطاریں۔</string>
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">These settings will be ignored as Lawnchair isn\'t set as the Recents screen provider</string>
+    <string name="quickswitch_ignored_warning">These settings will be ignored as AI اسسٹنٹ isn\'t set as the Recents screen provider</string>
     <string name="quickstep_incompatible">غیر مطابقت پذیر نظام کا انضمام</string>
     <string name="quickstep_incompatible_description">آپ کے آلے کو %1$s کے ذریعہ فراہم کردہ سسٹم اشاروں (جسے Quickstep کہا جاتا ہے) کے لیے ترتیب دیا گیا ہے، لیکن %1$s کا یہ ورژن آپ کے Android ورژن کے ساتھ مطابقت نہیں رکھتا ہے۔ اپنے آلے کا استعمال جاری رکھنے کے لیے، براہ کرم %1$s اپ ڈیٹس کو اَن انسٹال کریں یا %1$s کو سسٹم اشارہ فراہم کنندہ کے طور پر غیر فعال کریں۔</string>
     <string name="translucent_background">شفاف پس منظر</string>

--- a/lawnchair/res/values-ur/strings.xml
+++ b/lawnchair/res/values-ur/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI اسسٹنٹ
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-uz-rUZ/strings.xml
+++ b/lawnchair/res/values-uz-rUZ/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, Ai yordamchisi
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@
     <string name="time_weeks_ago">%dw</string>
     <string name="time_months_ago">%dmo</string>
     <string name="time_years_ago">%dy</string>
-    <string name="managed_by_lawnchair">Managed by Lawnchair</string>
+    <string name="managed_by_lawnchair">Managed by Ai yordamchisi</string>
     <!-- When mentioning settings UI -->
     <string name="smartspace_preferences">Afzalliklar</string>
     <string name="settings_button_text">Home settings</string>
@@ -69,7 +69,7 @@
     <string name="title_change_settings">Change settings</string>
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout Ai yordamchisi
 
     -->
     <string name="others_category_label">Others</string>
@@ -114,7 +114,7 @@
     <string name="folders_filter_duplicates">Only show unique apps</string>
     <string name="my_folder_label">My folder</string>
     <!-- A11y description -->
-    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, Lawnchair uses the performGlobalAction Accessibility service.</string>
+    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, Ai yordamchisi requires accessibility access.\n\nAi yordamchisi doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Ai yordamchisi discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, Ai yordamchisi uses the performGlobalAction Accessibility service.</string>
     <string name="x_with_y_count">%1$s (%2$d)</string>
     <string name="x_by_y">%1$d x %2$d</string>
     <string name="x_and_y">%1$s &amp; %2$s</string>
@@ -143,7 +143,7 @@
     <string name="quickstep_description">Clear All button, corner radius</string>
     <string name="about_label">Haqida</string>
     <string name="app_info_drop_target_label">App info</string>
-    <string name="debug_restart_launcher">Lawnchair qayta ishga tush</string>
+    <string name="debug_restart_launcher">Ai yordamchisi qayta ishga tush</string>
     <string name="experimental_features_label">Experimental features</string>
     <!-- Experimental features -->
     <string name="font_picker_label">Font customization</string>
@@ -171,7 +171,7 @@
     Notifications
 
     -->
-    <string name="set_default_launcher_tip">To access shortcuts and additional features, set Lawnchair as your default launcher</string>
+    <string name="set_default_launcher_tip">To access shortcuts and additional features, set Ai yordamchisi as your default launcher</string>
     <string name="notification_dots">Notification dots</string>
     <string name="show_notification_count">Show notification counter</string>
     <string name="notification_dots_color">Notification dot color</string>
@@ -344,7 +344,7 @@
     <string name="event_provider_missing_notification_dots">To use <xliff:g example="My Provider" id="providerName">%1$s</xliff:g>, turn on Notification Dots.</string>
     <!-- Toggle button for enabling Smartspace -->
     <string name="smartspace_widget_toggle_label">Show on home screen</string>
-    <string name="smartspace_widget_toggle_description">At a Glance can be manually added to the home screen by placing the Lawnchair widget</string>
+    <string name="smartspace_widget_toggle_description">At a Glance can be manually added to the home screen by placing the Ai yordamchisi widget</string>
     <!-- List of available providers -->
     <string name="smartspace_mode_label">At a Glance provider</string>
     <string name="smartspace_mode_google">Google</string>
@@ -415,18 +415,18 @@
     <string name="gesture_handler_open_assistant">Open assistant</string>
     <string name="pick_app_for_gesture">Pick app</string>
     <string name="dt2s_admin_hint_title">Admin permissions required</string>
-    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set Lawnchair as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
+    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set Ai yordamchisi as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
     <string name="dt2s_admin_warning">Kutish uchun ikki marta bosish o‘chiriladi.</string>
     <string name="d2ts_recents_a11y_hint_title">Turn on accessibility service</string>
-    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the Ai yordamchisi accessibility service. Tap \"Open settings\", select \"Ai yordamchisi\" and turn on \"Use Ai yordamchisi.\"\n\nAi yordamchisi uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Ai yordamchisi is not configured for that functionality and receives no events.</string>
     <string name="dt2s_recents_warning_open_settings">Open settings</string>
-    <string name="recents_a11y_hint">To use Open Recents screen, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="recents_a11y_hint">To use Open Recents screen, turn on the Ai yordamchisi accessibility service. Tap \"Open settings\", select \"Ai yordamchisi\" and turn on \"Use Ai yordamchisi.\"\n\nAi yordamchisi uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Ai yordamchisi is not configured for that functionality and receives no events.</string>
     <!--
 
     Bug reporting
 
     -->
-    <string name="lawnchair_bug_report">Lawnchair bug report</string>
+    <string name="lawnchair_bug_report">Ai yordamchisi bug report</string>
     <string name="crash_report_notif_title">%1$s crashed</string>
     <string name="action_upload_crash_report">Upload crash log</string>
     <string name="action_upload_error">Upload failed</string>
@@ -519,7 +519,7 @@
     <!-- Search providers -->
     <string name="search_provider_app_search">App search</string>
     <string name="search_provider_custom">Custom</string>
-    <string name="search_provider_sponsored_description">%1$s and Lawnchair have a revenue share agreement.\n\nSearching with %1$s helps support Lawnchair.</string>
+    <string name="search_provider_sponsored_description">%1$s and Ai yordamchisi have a revenue share agreement.\n\nSearching with %1$s helps support Ai yordamchisi.</string>
     <string name="app_label">App</string>
     <string name="website_label">Website</string>
     <string name="qsb_search_provider_app_required">App required</string>
@@ -552,7 +552,7 @@
     <string name="max_folder_columns">Maximum folder columns</string>
     <string name="max_folder_rows">Maximum folder rows</string>
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">These settings will be ignored as Lawnchair isn\'t set as the Recents screen provider</string>
+    <string name="quickswitch_ignored_warning">These settings will be ignored as Ai yordamchisi isn\'t set as the Recents screen provider</string>
     <string name="quickstep_incompatible">Incompatible system integration</string>
     <string name="quickstep_incompatible_description">Your device is configured to have system gestures (known as Quickstep) provided by %1$s, but this version of %1$s isn\'t compatible with your Android version. To continue using your device, please uninstall %1$s updates or disable %1$s as a system gesture provider.</string>
     <string name="translucent_background">Translucent background</string>

--- a/lawnchair/res/values-uz/strings.xml
+++ b/lawnchair/res/values-uz/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, Ai yordamchisi
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-vi-rVN/strings.xml
+++ b/lawnchair/res/values-vi-rVN/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, Trợ lý AI
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@
     <string name="time_weeks_ago">%dw</string>
     <string name="time_months_ago">%dmo</string>
     <string name="time_years_ago">%dy</string>
-    <string name="managed_by_lawnchair">Quản lí bởi Lawnchair</string>
+    <string name="managed_by_lawnchair">Quản lí bởi Trợ lý AI</string>
     <!-- When mentioning settings UI -->
     <string name="smartspace_preferences">Tùy chỉnh</string>
     <string name="settings_button_text">Cài đặt trang chủ</string>
@@ -69,7 +69,7 @@
     <string name="title_change_settings">Thay đổi cài đặt</string>
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout Trợ lý AI
 
     -->
     <string name="others_category_label">Khác</string>
@@ -114,7 +114,7 @@
     <string name="folders_filter_duplicates">Chỉ hiển thị các ứng dụng duy nhất</string>
     <string name="my_folder_label">Thư mục của tôi</string>
     <!-- A11y description -->
-    <string name="accessibility_service_description">Để thực hiện một số hành động nhất định (chẳng hạn như khóa điện thoại) khi thực hiện cử chỉ, Lawnchair cần có quyền truy cập trợ năng.\n\nLawnchair không theo dõi bất kỳ hành động nào của người dùng, mặc dù quyền làm như vậy là bắt buộc đối với tất cả các dịch vụ trợ năng. Lawnchair loại bỏ bất kỳ sự kiện nào được hệ thống gửi đi.\n\nĐể khóa điện thoại hoặc mở màn hình Gần đây, Lawnchair sử dụng dịch vụ Trợ năng performGlobalAction.</string>
+    <string name="accessibility_service_description">Để thực hiện một số hành động nhất định (chẳng hạn như khóa điện thoại) khi thực hiện cử chỉ, Trợ lý AI cần có quyền truy cập trợ năng.\n\nTrợ lý AI không theo dõi bất kỳ hành động nào của người dùng, mặc dù quyền làm như vậy là bắt buộc đối với tất cả các dịch vụ trợ năng. Trợ lý AI loại bỏ bất kỳ sự kiện nào được hệ thống gửi đi.\n\nĐể khóa điện thoại hoặc mở màn hình Gần đây, Trợ lý AI sử dụng dịch vụ Trợ năng performGlobalAction.</string>
     <string name="x_with_y_count">%1$s (%2$d)</string>
     <string name="x_by_y">%1$d x %2$d</string>
     <string name="x_and_y">%1$s &amp; %2$s</string>
@@ -143,7 +143,7 @@
     <string name="quickstep_description">Xóa tất cả nút, bán kính góc</string>
     <string name="about_label">Giới thiệu</string>
     <string name="app_info_drop_target_label">Thông tin ứng dụng</string>
-    <string name="debug_restart_launcher">Khởi chạy lại Lawnchair</string>
+    <string name="debug_restart_launcher">Khởi chạy lại Trợ lý AI</string>
     <string name="experimental_features_label">Chức năng thử nghiệm</string>
     <!-- Experimental features -->
     <string name="font_picker_label">Đổi phông chữ</string>
@@ -171,7 +171,7 @@
     Notifications
 
     -->
-    <string name="set_default_launcher_tip">Để truy cập các phím tắt và tính năng bổ sung, hãy đặt Lawnchair làm ứng dụng mặc định màn hình chính của bạn</string>
+    <string name="set_default_launcher_tip">Để truy cập các phím tắt và tính năng bổ sung, hãy đặt Trợ lý AI làm ứng dụng mặc định màn hình chính của bạn</string>
     <string name="notification_dots">Dấu chấm thông báo</string>
     <string name="show_notification_count">Hiển thị số đếm thông báo</string>
     <string name="notification_dots_color">Màu chấm thông báo</string>
@@ -344,7 +344,7 @@
     <string name="event_provider_missing_notification_dots">Để sử dụng <xliff:g example="My Provider" id="providerName">%1$s</xliff:g>, bật chức năng Chấm Thông báo.</string>
     <!-- Toggle button for enabling Smartspace -->
     <string name="smartspace_widget_toggle_label">Hiển thị trên màn hình chính</string>
-    <string name="smartspace_widget_toggle_description">Có thể thêm Xem nhanh vào màn hình chính bằng cách đặt tiện ích Lawnchair</string>
+    <string name="smartspace_widget_toggle_description">Có thể thêm Xem nhanh vào màn hình chính bằng cách đặt tiện ích Trợ lý AI</string>
     <!-- List of available providers -->
     <string name="smartspace_mode_label">Nhà cung cấp Xem nhanh</string>
     <string name="smartspace_mode_google">Google</string>
@@ -415,18 +415,18 @@
     <string name="gesture_handler_open_assistant">Mở trợ lý ảo</string>
     <string name="pick_app_for_gesture">Chọn ứng dụng</string>
     <string name="dt2s_admin_hint_title">Cần quyền Quản trị viên</string>
-    <string name="dt2s_admin_hint">Để sử dụng Chạm Hai Lần để Tắt, hãy đặt Lawnchair làm ứng dụng quản trị thiết bị. Nhấn \"Mở cài đặt\", sau đó nhấn \"Kích hoạt ứng dụng quản trị thiết bị này.\"</string>
+    <string name="dt2s_admin_hint">Để sử dụng Chạm Hai Lần để Tắt, hãy đặt Trợ lý AI làm ứng dụng quản trị thiết bị. Nhấn \"Mở cài đặt\", sau đó nhấn \"Kích hoạt ứng dụng quản trị thiết bị này.\"</string>
     <string name="dt2s_admin_warning">Nhấp đôi để khoá màn hình sẽ được tắt.</string>
     <string name="d2ts_recents_a11y_hint_title">Bật dịch vụ trợ năng</string>
-    <string name="dt2s_a11y_hint">Để sử dụng Chạm Hai Lần, hãy bật dịch vụ trợ năng Lawnchair. Nhấn \"Mở cài đặt\", chọn \"Lawnchair\" và bật \"Sử dụng Lawnchair.\"\n\nLawnchair sử dụng phương thức `performGlobalAction` của Khả năng tiếp cận để thực hiện hành động này. Đây là quyền nhạy cảm cho phép giám sát các ứng dụng khác. Tuy nhiên, Lawnchair không được sử dụng cho mục đích đó.</string>
+    <string name="dt2s_a11y_hint">Để sử dụng Chạm Hai Lần, hãy bật dịch vụ trợ năng Trợ lý AI. Nhấn \"Mở cài đặt\", chọn \"Trợ lý AI\" và bật \"Sử dụng Trợ lý AI.\"\n\nTrợ lý AI sử dụng phương thức `performGlobalAction` của Khả năng tiếp cận để thực hiện hành động này. Đây là quyền nhạy cảm cho phép giám sát các ứng dụng khác. Tuy nhiên, Trợ lý AI không được sử dụng cho mục đích đó.</string>
     <string name="dt2s_recents_warning_open_settings">Mở Cài đặt</string>
-    <string name="recents_a11y_hint">Để sử dụng màn hình Mở gần đây, hãy bật dịch vụ trợ năng Lawnchair. Nhấn \"Mở cài đặt\", chọn \"Lawnchair\" và bật \"Sử dụng Lawnchair\".\n\nLawnchair sử dụng phương thức `performGlobalAction` của Accessibility để thực hiện hành động này. Đây là quyền nhạy cảm cho phép giám sát các ứng dụng khác. Tuy nhiên, Lawnchair không được sử dụng cho mục đích đó.</string>
+    <string name="recents_a11y_hint">Để sử dụng màn hình Mở gần đây, hãy bật dịch vụ trợ năng Trợ lý AI. Nhấn \"Mở cài đặt\", chọn \"Trợ lý AI\" và bật \"Sử dụng Trợ lý AI\".\n\nTrợ lý AI sử dụng phương thức `performGlobalAction` của Accessibility để thực hiện hành động này. Đây là quyền nhạy cảm cho phép giám sát các ứng dụng khác. Tuy nhiên, Trợ lý AI không được sử dụng cho mục đích đó.</string>
     <!--
 
     Bug reporting
 
     -->
-    <string name="lawnchair_bug_report">Báo lỗi của Lawnchair</string>
+    <string name="lawnchair_bug_report">Báo lỗi của Trợ lý AI</string>
     <string name="crash_report_notif_title">%1$s đã dừng hoạt động</string>
     <string name="action_upload_crash_report">Tải lên thông tin sự cố</string>
     <string name="action_upload_error">Tải lên thất bại</string>
@@ -519,7 +519,7 @@
     <!-- Search providers -->
     <string name="search_provider_app_search">Tìm kiếm ứng dụng</string>
     <string name="search_provider_custom">Tùy chỉnh</string>
-    <string name="search_provider_sponsored_description">%1$s và Lawnchair có thỏa thuận chia sẻ doanh thu.\n\nTìm kiếm với %1$s giúp hỗ trợ Lawnchair.</string>
+    <string name="search_provider_sponsored_description">%1$s và Trợ lý AI có thỏa thuận chia sẻ doanh thu.\n\nTìm kiếm với %1$s giúp hỗ trợ Trợ lý AI.</string>
     <string name="app_label">Ứng dụng</string>
     <string name="website_label">Trang web</string>
     <string name="qsb_search_provider_app_required">Yêu cầu ứng dụng được cài đặt trên máy</string>
@@ -551,7 +551,7 @@
     <string name="max_folder_columns">Số cột của thư mục tối đa</string>
     <string name="max_folder_rows">Số hàng thư mục tối đa</string>
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">Những thiết lập này sẽ bị bỏ qua vì Lawnchair không được đặt làm nhà cung cấp màn hình Gần đây</string>
+    <string name="quickswitch_ignored_warning">Những thiết lập này sẽ bị bỏ qua vì Trợ lý AI không được đặt làm nhà cung cấp màn hình Gần đây</string>
     <string name="quickstep_incompatible">Tích hợp hệ thống không tương thích</string>
     <string name="quickstep_incompatible_description">Thiết bị của bạn được cấu hình để có cử chỉ hệ thống (được gọi là Quickstep) được cung cấp bởi %1$s, nhưng phiên bản này của %1$s không tương thích với phiên bản Android của bạn. Để tiếp tục sử dụng thiết bị của bạn, vui lòng gỡ cài đặt các bản cập nhật cho %1$s hoặc vô hiệu hóa %1$s với tư cách là nhà cung cấp cử chỉ hệ thống.</string>
     <string name="translucent_background">Nền trong suốt</string>

--- a/lawnchair/res/values-vi/strings.xml
+++ b/lawnchair/res/values-vi/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, Trợ lý AI
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-zh-rCN/strings.xml
+++ b/lawnchair/res/values-zh-rCN/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI助手
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@
     <string name="time_weeks_ago">%dw</string>
     <string name="time_months_ago">%dmo</string>
     <string name="time_years_ago">%dy</string>
-    <string name="managed_by_lawnchair">由 Lawnchair 管理</string>
+    <string name="managed_by_lawnchair">由 AI助手 管理</string>
     <!-- When mentioning settings UI -->
     <string name="smartspace_preferences">首选项</string>
     <string name="settings_button_text">启动器设置</string>
@@ -69,7 +69,7 @@
     <string name="title_change_settings">更改设置</string>
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout AI助手
 
     -->
     <string name="others_category_label">其他</string>
@@ -114,7 +114,7 @@
     <string name="folders_filter_duplicates">仅显示唯一应用</string>
     <string name="my_folder_label">我的文件夹</string>
     <!-- A11y description -->
-    <string name="accessibility_service_description">为了在您执行手势时进行某些操作（例如锁定手机），Lawnchair 需要获取无障碍服务权限。\n\nLawnchair 不会监视您的任何用户操作，尽管所有无障碍服务都必须申请该权限。Lawnchair 会丢弃系统发送的任何事件。\n\n为了锁定您的手机或打开最近任务界面，Lawnchair 使用 performGlobalAction 无障碍服务。</string>
+    <string name="accessibility_service_description">为了在您执行手势时进行某些操作（例如锁定手机），AI助手 需要获取无障碍服务权限。\n\nAI助手 不会监视您的任何用户操作，尽管所有无障碍服务都必须申请该权限。AI助手 会丢弃系统发送的任何事件。\n\n为了锁定您的手机或打开最近任务界面，AI助手 使用 performGlobalAction 无障碍服务。</string>
     <string name="x_with_y_count">%1$s (%2$d)</string>
     <string name="x_by_y">%1$d x %2$d</string>
     <string name="x_and_y">%1$s &amp; %2$s</string>
@@ -143,7 +143,7 @@
     <string name="quickstep_description">全部清除按钮，圆角半径</string>
     <string name="about_label">关于</string>
     <string name="app_info_drop_target_label">应用信息</string>
-    <string name="debug_restart_launcher">重启 Lawnchair</string>
+    <string name="debug_restart_launcher">重启 AI助手</string>
     <string name="experimental_features_label">实验性功能</string>
     <!-- Experimental features -->
     <string name="font_picker_label">自定义字体</string>
@@ -171,7 +171,7 @@
     Notifications
 
     -->
-    <string name="set_default_launcher_tip">要访问快捷方式和其他功能，请将 Lawnchair 设置为默认启动器</string>
+    <string name="set_default_launcher_tip">要访问快捷方式和其他功能，请将 AI助手 设置为默认启动器</string>
     <string name="notification_dots">通知圆点</string>
     <string name="show_notification_count">显示通知数量</string>
     <string name="notification_dots_color">通知圆点颜色</string>
@@ -344,7 +344,7 @@
     <string name="event_provider_missing_notification_dots">要使用<xliff:g example="My Provider" id="providerName">%1$s</xliff:g>，请打开通知圆点</string>
     <!-- Toggle button for enabling Smartspace -->
     <string name="smartspace_widget_toggle_label">在主屏幕显示</string>
-    <string name="smartspace_widget_toggle_description">资讯一览可以通过将 Lawnchair 小部件放置在主屏幕上来手动添加</string>
+    <string name="smartspace_widget_toggle_description">资讯一览可以通过将 AI助手 小部件放置在主屏幕上来手动添加</string>
     <!-- List of available providers -->
     <string name="smartspace_mode_label">资讯一览提供程序</string>
     <string name="smartspace_mode_google">Google</string>
@@ -415,18 +415,18 @@
     <string name="gesture_handler_open_assistant">打开助手</string>
     <string name="pick_app_for_gesture">选择应用</string>
     <string name="dt2s_admin_hint_title">需要管理员权限</string>
-    <string name="dt2s_admin_hint">要使用双击息屏，请把 Lawnchair 设置为设备管理员应用，点击\"打开设置\"，然后点击\"启用设备管理员应用\"</string>
+    <string name="dt2s_admin_hint">要使用双击息屏，请把 AI助手 设置为设备管理员应用，点击\"打开设置\"，然后点击\"启用设备管理员应用\"</string>
     <string name="dt2s_admin_warning">双击息屏功能将被关闭。</string>
     <string name="d2ts_recents_a11y_hint_title">打开无障碍服务</string>
-    <string name="dt2s_a11y_hint">要使用双击息屏，请开启 Lawnchair 的无障碍服务。点击“打开设置”，选择“Lawnchair”，并开启“使用Lawnchair”。\n\nLawnchair 使用无障碍的 performGlobalAction 方法来执行此操作。这是一个敏感权限，允许监控其他应用。然而，Lawnchair 并未配置此功能，因此不会接收到任何事件。</string>
+    <string name="dt2s_a11y_hint">要使用双击息屏，请开启 AI助手 的无障碍服务。点击“打开设置”，选择“AI助手”，并开启“使用AI助手”。\n\nAI助手 使用无障碍的 performGlobalAction 方法来执行此操作。这是一个敏感权限，允许监控其他应用。然而，AI助手 并未配置此功能，因此不会接收到任何事件。</string>
     <string name="dt2s_recents_warning_open_settings">打开设置</string>
-    <string name="recents_a11y_hint">若要使用打开最近任务界面，请开启 Lawnchair 的无障碍服务。点击 “打开设置”，选择Lawnchair，然后开启 “使用 Lawnchair” 选项。\n\nLawnchair 使用无障碍服务的 performGlobalAction 方法来执行此操作。这是一个敏感权限，它允许应用监控其他应用。但是Lawnchair 并未配置该功能，也不会接收任何事件。</string>
+    <string name="recents_a11y_hint">若要使用打开最近任务界面，请开启 AI助手 的无障碍服务。点击 “打开设置”，选择AI助手，然后开启 “使用 AI助手” 选项。\n\nAI助手 使用无障碍服务的 performGlobalAction 方法来执行此操作。这是一个敏感权限，它允许应用监控其他应用。但是AI助手 并未配置该功能，也不会接收任何事件。</string>
     <!--
 
     Bug reporting
 
     -->
-    <string name="lawnchair_bug_report">Lawnchair 错误报告</string>
+    <string name="lawnchair_bug_report">AI助手 错误报告</string>
     <string name="crash_report_notif_title">%1$s 已崩溃</string>
     <string name="action_upload_crash_report">上传崩溃日志</string>
     <string name="action_upload_error">上传失败</string>
@@ -519,7 +519,7 @@
     <!-- Search providers -->
     <string name="search_provider_app_search">应用搜索</string>
     <string name="search_provider_custom">自定义</string>
-    <string name="search_provider_sponsored_description">%1$s 和 Lawnchair 有收益分成协议。\n\n使用 %1$s 进行搜索有助于支持 Lawnchair。</string>
+    <string name="search_provider_sponsored_description">%1$s 和 AI助手 有收益分成协议。\n\n使用 %1$s 进行搜索有助于支持 AI助手。</string>
     <string name="app_label">应用</string>
     <string name="website_label">网站</string>
     <string name="qsb_search_provider_app_required">未安装应用</string>
@@ -551,7 +551,7 @@
     <string name="max_folder_columns">最大文件夹列数</string>
     <string name="max_folder_rows">最大文件夹行数</string>
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">由于 Lawnchair 未被设为最近任务应用，这些设置将不会生效</string>
+    <string name="quickswitch_ignored_warning">由于 AI助手 未被设为最近任务应用，这些设置将不会生效</string>
     <string name="quickstep_incompatible">不兼容的系统集成</string>
     <string name="quickstep_incompatible_description">您的设备已配置为使用 %1$s 提供的系统手势 (称为 Quickstep)，但此版本的 %1$s 与您的 Android 版本不兼容。要继续使用您的设备，请卸载 %1$s 更新或禁用 %1$s 作为系统手势提供程序。</string>
     <string name="translucent_background">半透明背景</string>

--- a/lawnchair/res/values-zh-rHK/strings.xml
+++ b/lawnchair/res/values-zh-rHK/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI助手
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values-zh-rTW/strings.xml
+++ b/lawnchair/res/values-zh-rTW/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI助手
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@
     <string name="time_weeks_ago">%dw</string>
     <string name="time_months_ago">%dmo</string>
     <string name="time_years_ago">%dy</string>
-    <string name="managed_by_lawnchair">由 Lawnchair 管理</string>
+    <string name="managed_by_lawnchair">由 AI助手 管理</string>
     <!-- When mentioning settings UI -->
     <string name="smartspace_preferences">偏好設定</string>
     <string name="settings_button_text">主畫面設定</string>
@@ -69,7 +69,7 @@
     <string name="title_change_settings">變更設定</string>
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout AI助手
 
     -->
     <string name="others_category_label">其他</string>
@@ -114,7 +114,7 @@
     <string name="folders_filter_duplicates">僅顯示單一應用程式</string>
     <string name="my_folder_label">我的資料夾</string>
     <!-- A11y description -->
-    <string name="accessibility_service_description">Lawnchair 需要存取無障礙服務，才能透過手勢執行特定動作 (例如鎖定您的裝置)。\n\n存取所有無障礙服務都需要這項權限，但 Lawnchair 不會監視任何使用者操作，並會捨棄任何系統發送的事件。\n\nLawnchair 使用 performGlobalAction (執行全域動作)無障礙服務以鎖定您的裝置或開啟最近使用畫面。</string>
+    <string name="accessibility_service_description">AI助手 需要存取無障礙服務，才能透過手勢執行特定動作 (例如鎖定您的裝置)。\n\n存取所有無障礙服務都需要這項權限，但 AI助手 不會監視任何使用者操作，並會捨棄任何系統發送的事件。\n\nAI助手 使用 performGlobalAction (執行全域動作)無障礙服務以鎖定您的裝置或開啟最近使用畫面。</string>
     <string name="x_with_y_count">%1$s (%2$d)</string>
     <string name="x_by_y">%1$d × %2$d</string>
     <string name="x_and_y">%1$s &amp; %2$s</string>
@@ -143,7 +143,7 @@
     <string name="quickstep_description">清除全部按鈕、圓角大小</string>
     <string name="about_label">關於</string>
     <string name="app_info_drop_target_label">應用程式資訊</string>
-    <string name="debug_restart_launcher">Restart Lawnchair</string>
+    <string name="debug_restart_launcher">Restart AI助手</string>
     <string name="experimental_features_label">實驗性功能</string>
     <!-- Experimental features -->
     <string name="font_picker_label">自訂字體</string>
@@ -171,7 +171,7 @@
     Notifications
 
     -->
-    <string name="set_default_launcher_tip">將 Lawnchair 設為預設啟動器來存取捷徑和更多功能</string>
+    <string name="set_default_launcher_tip">將 AI助手 設為預設啟動器來存取捷徑和更多功能</string>
     <string name="notification_dots">通知圓點</string>
     <string name="show_notification_count">顯示通知圖示數字</string>
     <string name="notification_dots_color">通知圓點顏色</string>
@@ -344,7 +344,7 @@
     <string name="event_provider_missing_notification_dots">使用 <xliff:g example="My Provider" id="providerName">%1$s</xliff:g>，開啟通知圓點。</string>
     <!-- Toggle button for enabling Smartspace -->
     <string name="smartspace_widget_toggle_label">在主畫面顯示</string>
-    <string name="smartspace_widget_toggle_description">放置 Lawnchair 小工具即可手動將資訊一覽新增至主畫面</string>
+    <string name="smartspace_widget_toggle_description">放置 AI助手 小工具即可手動將資訊一覽新增至主畫面</string>
     <!-- List of available providers -->
     <string name="smartspace_mode_label">資訊一覽提供者</string>
     <string name="smartspace_mode_google">Google</string>
@@ -415,18 +415,18 @@
     <string name="gesture_handler_open_assistant">開啟助理</string>
     <string name="pick_app_for_gesture">選擇應用程式</string>
     <string name="dt2s_admin_hint_title">需要管理員權限</string>
-    <string name="dt2s_admin_hint">如要使用輕觸兩下休眠，請將 Lawnchair 設為裝置管理員應用程式。按下 \"開啟設定\" 然後選擇 \"啟用這個裝置管理員應用程式\"。</string>
+    <string name="dt2s_admin_hint">如要使用輕觸兩下休眠，請將 AI助手 設為裝置管理員應用程式。按下 \"開啟設定\" 然後選擇 \"啟用這個裝置管理員應用程式\"。</string>
     <string name="dt2s_admin_warning">將會停用輕觸兩下休眠。</string>
     <string name="d2ts_recents_a11y_hint_title">啟用無障礙服務</string>
-    <string name="dt2s_a11y_hint">如要使用輕觸兩下休眠，請啟用 Lawnchair 無障礙服務。按下 \"開啟設定\" 選擇 \"Lawnchair\"，再開啟 \"使用 Lawnchair\" 控制項。\n\nLawnchair 使用 performGlobalAction 無障礙服務執行這項動作。此為允許監控其他應用程式的敏感權限，然而 Lawnchair 並未配置與接收任何事件。</string>
+    <string name="dt2s_a11y_hint">如要使用輕觸兩下休眠，請啟用 AI助手 無障礙服務。按下 \"開啟設定\" 選擇 \"AI助手\"，再開啟 \"使用 AI助手\" 控制項。\n\nAI助手 使用 performGlobalAction 無障礙服務執行這項動作。此為允許監控其他應用程式的敏感權限，然而 AI助手 並未配置與接收任何事件。</string>
     <string name="dt2s_recents_warning_open_settings">開啟設定</string>
-    <string name="recents_a11y_hint">如要開啟最近使用畫面，請啟用 Lawnchair 無障礙服務。按下 \"開啟設定\" 選擇 \"Lawnchair\"，再開啟 \"使用 Lawnchair\" 控制項。\n\nLawnchair 使用 performGlobalAction 無障礙服務執行這項動作。此為允許監控其他應用程式的敏感權限，然而 Lawnchair 並未配置與接收任何事件。</string>
+    <string name="recents_a11y_hint">如要開啟最近使用畫面，請啟用 AI助手 無障礙服務。按下 \"開啟設定\" 選擇 \"AI助手\"，再開啟 \"使用 AI助手\" 控制項。\n\nAI助手 使用 performGlobalAction 無障礙服務執行這項動作。此為允許監控其他應用程式的敏感權限，然而 AI助手 並未配置與接收任何事件。</string>
     <!--
 
     Bug reporting
 
     -->
-    <string name="lawnchair_bug_report">回報 Lawnchair 問題</string>
+    <string name="lawnchair_bug_report">回報 AI助手 問題</string>
     <string name="crash_report_notif_title">%1$s 已崩潰</string>
     <string name="action_upload_crash_report">上傳錯誤報告</string>
     <string name="action_upload_error">上傳失敗</string>
@@ -519,7 +519,7 @@
     <!-- Search providers -->
     <string name="search_provider_app_search">應用程式搜尋</string>
     <string name="search_provider_custom">自訂</string>
-    <string name="search_provider_sponsored_description">%1$s 和 Lawnchair 擁有共享收入協議。\n\n使用 %1$s 搜尋將可幫助 Lawnchair。</string>
+    <string name="search_provider_sponsored_description">%1$s 和 AI助手 擁有共享收入協議。\n\n使用 %1$s 搜尋將可幫助 AI助手。</string>
     <string name="app_label">應用程式</string>
     <string name="website_label">網站</string>
     <string name="qsb_search_provider_app_required">需要應用程式</string>
@@ -551,7 +551,7 @@
     <string name="max_folder_columns">最大資料夾列數</string>
     <string name="max_folder_rows">最大資料夾列數</string>
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">Lawnchair 未設為最近使用畫面提供者時將會略過這些設定</string>
+    <string name="quickswitch_ignored_warning">AI助手 未設為最近使用畫面提供者時將會略過這些設定</string>
     <string name="quickstep_incompatible">系統整合不相容</string>
     <string name="quickstep_incompatible_description">您的裝置已設定使用 %1$s 提供的手勢系統 (稱為 Quickstep)，但這個版本的 %1$s 與您的 Android 不相容。如要繼續使用您的裝置，請解除安裝 %1$s 更新或停用手勢系統提供者 %1$s。</string>
     <string name="translucent_background">半透明背景</string>

--- a/lawnchair/res/values-zu/strings.xml
+++ b/lawnchair/res/values-zu/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI Assistant
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2021, Lawnchair
+  ~ Copyright 2021, AI Assistant
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -73,7 +73,7 @@
     <string name="time_months_ago">%dmo</string>
     <string name="time_years_ago">%dy</string>
 
-    <string name="managed_by_lawnchair">Managed by Lawnchair</string>
+    <string name="managed_by_lawnchair">Managed by AI Assistant</string>
 
     <!-- When mentioning settings UI -->
     <string name="smartspace_preferences">Preferences</string>
@@ -83,7 +83,7 @@
 
     <!--
 
-    General "words" used throughout Lawnchair
+    General "words" used throughout AI Assistant
 
     -->
     <string name="others_category_label">Others</string>
@@ -140,7 +140,7 @@
     <string name="my_folder_label">My folder</string>
 
     <!-- A11y description -->
-    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, Lawnchair uses the performGlobalAction Accessibility service.</string>
+    <string name="accessibility_service_description">To perform certain actions (such as locking your phone) when performing a gesture, AI Assistant requires accessibility access.\n\nAI Assistant doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. AI Assistant discards any event sent by the system.\n\nIn order to lock your phone, or to open the Recents screen, AI Assistant uses the performGlobalAction Accessibility service.</string>
 
     <string name="iconPackPackageDefault" translatable="false">""</string>
 
@@ -184,7 +184,7 @@
     <string name="about_label">About</string>
 
     <string name="app_info_drop_target_label">App info</string>
-    <string name="debug_restart_launcher">Restart Lawnchair</string>
+    <string name="debug_restart_launcher">Restart AI Assistant</string>
     <string name="experimental_features_label">Experimental features</string>
 
     <!-- Experimental features -->
@@ -222,7 +222,7 @@
 
     -->
 
-    <string name="set_default_launcher_tip">To access shortcuts and additional features, set Lawnchair as your default launcher</string>
+    <string name="set_default_launcher_tip">To access shortcuts and additional features, set AI Assistant as your default launcher</string>
 
     <string name="notification_dots">Notification dots</string>
     <string name="show_notification_count">Show notification counter</string>
@@ -438,11 +438,11 @@
 
     <!-- Toggle button for enabling Smartspace -->
     <string name="smartspace_widget_toggle_label">Show on home screen</string>
-    <string name="smartspace_widget_toggle_description">At a Glance can be manually added to the home screen by placing the Lawnchair widget</string>
+    <string name="smartspace_widget_toggle_description">At a Glance can be manually added to the home screen by placing the AI Assistant widget</string>
 
     <!-- List of available providers -->
     <string name="smartspace_mode_label">At a Glance provider</string>
-    <string name="smartspace_mode_lawnchair" translatable="false">Lawnchair</string>
+    <string name="smartspace_mode_lawnchair" translatable="false">AI Assistant</string>
     <string name="smartspace_mode_google">Google</string>
     <string name="smartspace_mode_google_search">Google Search</string>
     <string name="smartspace_mode_smartspacer" translatable="false">Smartspacer</string>
@@ -528,22 +528,22 @@
     <string name="pick_app_for_gesture">Pick app</string>
 
     <string name="dt2s_admin_hint_title">Admin permissions required</string>
-    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set Lawnchair as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
+    <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set AI Assistant as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
     <string name="dt2s_admin_warning">Double-Tap to Sleep will be turned off.</string>
 
 
     <string name="d2ts_recents_a11y_hint_title">Turn on accessibility service</string>
-    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="dt2s_a11y_hint">To use Double-Tap to Sleep, turn on the AI Assistant accessibility service. Tap \"Open settings\", select \"AI Assistant\" and turn on \"Use AI Assistant.\"\n\nAI Assistant uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, AI Assistant is not configured for that functionality and receives no events.</string>
     <string name="dt2s_recents_warning_open_settings">Open settings</string>
 
-    <string name="recents_a11y_hint">To use Open Recents screen, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"\n\nLawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
+    <string name="recents_a11y_hint">To use Open Recents screen, turn on the AI Assistant accessibility service. Tap \"Open settings\", select \"AI Assistant\" and turn on \"Use AI Assistant.\"\n\nAI Assistant uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, AI Assistant is not configured for that functionality and receives no events.</string>
 
     <!--
 
     Bug reporting
 
     -->
-    <string name="lawnchair_bug_report">Lawnchair bug report</string>
+    <string name="lawnchair_bug_report">AI Assistant bug report</string>
     <string name="crash_report_notif_title">%1$s crashed</string>
     <string name="action_upload_crash_report">Upload crash log</string>
 
@@ -630,7 +630,7 @@
     <string name="search_bar_settings">Search bar settings</string>
     <string name="hotseat_mode_label">Search bar widget</string>
     <string name="hotseat_mode_disabled">Disabled</string>
-    <string name="hotseat_mode_lawnchair" translatable="false">Lawnchair</string>
+    <string name="hotseat_mode_lawnchair" translatable="false">AI Assistant</string>
     <string name="hotseat_mode_google_search">Google Search bar</string>
 
     <string name="qsb_hotseat_background_transparency">Background opacity</string>
@@ -683,7 +683,7 @@
     <string name="search_provider_kagi" translatable="false">Kagi</string>
     <string name="search_provider_custom">Custom</string>
 
-    <string name="search_provider_sponsored_description">%1$s and Lawnchair have a revenue share agreement.\n\nSearching with %1$s helps support Lawnchair.</string>
+    <string name="search_provider_sponsored_description">%1$s and AI Assistant have a revenue share agreement.\n\nSearching with %1$s helps support AI Assistant.</string>
 
     <string name="app_label">App</string>
     <string name="website_label">Website</string>
@@ -727,7 +727,7 @@
     <string name="max_folder_rows">Maximum folder rows</string>
 
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">These settings will be ignored as Lawnchair isn\'t set as the Recents screen provider</string>
+    <string name="quickswitch_ignored_warning">These settings will be ignored as AI Assistant isn\'t set as the Recents screen provider</string>
 
     <string name="quickstep_incompatible">Incompatible system integration</string>
     <string name="quickstep_incompatible_description">Your device is configured to have system gestures (known as Quickstep) provided by %1$s, but this version of %1$s isn\'t compatible with your Android version. To continue using your device, please uninstall %1$s updates or disable %1$s as a system gesture provider.</string>

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/PreferencesDashboard.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/PreferencesDashboard.kt
@@ -40,7 +40,6 @@ import app.lawnchair.preferences.preferenceManager
 import app.lawnchair.preferences2.preferenceManager2
 import app.lawnchair.ui.OverflowMenu
 import app.lawnchair.ui.preferences.LocalNavController
-import app.lawnchair.ui.preferences.components.AnnouncementPreference
 import app.lawnchair.ui.preferences.components.controls.PreferenceCategory
 import app.lawnchair.ui.preferences.components.controls.WarningPreference
 import app.lawnchair.ui.preferences.components.layout.ClickableIcon
@@ -49,7 +48,6 @@ import app.lawnchair.ui.preferences.components.layout.PreferenceDivider
 import app.lawnchair.ui.preferences.components.layout.PreferenceLayout
 import app.lawnchair.ui.preferences.components.layout.PreferenceTemplate
 import app.lawnchair.ui.preferences.data.liveinfo.SyncLiveInformation
-import app.lawnchair.ui.preferences.navigation.About
 import app.lawnchair.ui.preferences.navigation.AppDrawer
 import app.lawnchair.ui.preferences.navigation.CreateBackup
 import app.lawnchair.ui.preferences.navigation.DebugMenu
@@ -88,8 +86,6 @@ fun PreferencesDashboard(
         backArrowVisible = false,
         actions = { PreferencesOverflowMenu(currentRoute = currentRoute, onNavigate = onNavigate) },
     ) {
-        AnnouncementPreference()
-
         if (BuildConfig.APPLICATION_ID.contains("nightly") || BuildConfig.DEBUG) {
             PreferencesDebugWarning()
             Spacer(modifier = Modifier.height(8.dp))
@@ -178,13 +174,6 @@ fun PreferencesDashboard(
                 )
             }
 
-            PreferenceCategory(
-                label = stringResource(R.string.about_label),
-                description = "${context.getString(R.string.derived_app_name)} ${BuildConfig.MAJOR_VERSION}",
-                iconResource = R.drawable.ic_about,
-                onNavigate = { onNavigate(About) },
-                isSelected = currentRoute is About,
-            )
         }
     }
 }


### PR DESCRIPTION
## Summary
- remove announcement banner and About section from settings dashboard
- replace "Lawnchair" with localized "AI Assistant" across string resources

## Testing
- `./gradlew lint` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b21a0eaf2c8325afb4c84cbaf671ac