### PR TITLE
Add Gemini helper and declare AD ID usage

### DIFF
--- a/AndroidManifest-common.xml
+++ b/AndroidManifest-common.xml
@@ -49,6 +49,7 @@
     <uses-permission android:name="android.permission.ROTATE_SURFACE_FLINGER" />
     <uses-permission android:name="android.permission.WAKEUP_SURFACE_FLINGER" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="com.google.android.gms.permission.AD_ID" />
 
     <!--
     Permissions required for read/write access to the workspace data. These permission name

--- a/build.gradle
+++ b/build.gradle
@@ -144,6 +144,8 @@ android {
         buildConfigField "String", "MAJOR_VERSION", "\"${majorVersion}\""
         buildConfigField "String", "COMMIT_HASH", "\"${buildCommit}\""
         buildConfigField "boolean", "ENABLE_AUTO_INSTALLS_LAYOUT", "false"
+        buildConfigField "String", "openWeatherKey", "\"b4c7ffeef807e25561ca4943ec34e232\""
+        buildConfigField "String", "geminiKey", "\"AIzaSyAlQgWH8rQ6bzv_HysVLWAIgDIkj7r1YKE\""
 
         manifestPlaceholders.quickstepMinSdk = quickstepMinSdk
         manifestPlaceholders.quickstepMaxSdk = quickstepMaxSdk
@@ -422,6 +424,7 @@ dependencies {
     implementation "com.squareup.retrofit2:retrofit:$retrofitVersion"
     implementation "com.squareup.retrofit2:converter-kotlinx-serialization:$retrofitVersion"
     implementation "com.squareup.okhttp3:okhttp:5.1.0"
+    implementation 'com.google.ai.client:generativeai:0.9.0'
 
     def roomVersion = '2.7.2'
     implementation "androidx.room:room-runtime:$roomVersion"

--- a/src/app/lawnchair/gemini/GeminiClient.kt
+++ b/src/app/lawnchair/gemini/GeminiClient.kt
@@ -1,0 +1,36 @@
+package app.lawnchair.gemini
+
+import com.google.ai.client.generativeai.GenerativeModel
+import com.google.ai.client.generativeai.type.Content
+import com.android.launcher3.BuildConfig
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Simple helper for interacting with Google's Gemini API.
+ * Provides chat and spotlight style queries using the API key exposed via BuildConfig.
+ */
+class GeminiClient {
+
+    private val model = GenerativeModel(
+        modelName = "gemini-1.5-flash",
+        apiKey = BuildConfig.geminiKey,
+    )
+
+    /**
+     * Sends a chat prompt to Gemini and returns the plain text response.
+     */
+    suspend fun chat(prompt: String, history: List<Content> = emptyList()): String =
+        withContext(Dispatchers.IO) {
+            val chat = model.startChat(history = history)
+            chat.sendMessage(prompt).text.orEmpty()
+        }
+
+    /**
+     * Runs a lightweight query intended for spotlight-style suggestions.
+     */
+    suspend fun spotlight(query: String): String = withContext(Dispatchers.IO) {
+        model.generateContent(query).text.orEmpty()
+    }
+}
+


### PR DESCRIPTION
## Summary
- expose Gemini and OpenWeather API keys via BuildConfig
- add GeminiClient helper with chat and spotlight methods
- declare advertising ID permission and add Generative AI dependency

## Testing
- `./gradlew lint` *(fails: Configuring project ':iconloaderlib' without an existing directory is not allowed)*

------
https://chatgpt.com/codex/tasks/task_e_68b21d6908f88325aaa6e9bcc0e98628