### PR TITLE
Add Gemini chat activity and spotlight composable

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -73,5 +73,11 @@
                 android:value="${packageName}.grid_control" />
         </activity>
 
+        <!-- Simple chat interface for interacting with Gemini -->
+        <activity
+            android:name="app.lawnchair.gemini.GeminiChatActivity"
+            android:exported="false"
+            android:theme="@style/AppTheme" />
+
     </application>
 </manifest>

--- a/src/app/lawnchair/gemini/GeminiChatActivity.kt
+++ b/src/app/lawnchair/gemini/GeminiChatActivity.kt
@@ -1,0 +1,60 @@
+package app.lawnchair.gemini
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
+
+/**
+ * Simple activity allowing users to chat with Google Gemini.
+ * Uses [GeminiClient] for network requests and keeps UI minimal to
+ * match the existing Lawnchair design language.
+ */
+class GeminiChatActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val client = GeminiClient()
+        setContent {
+            MaterialTheme {
+                var query by remember { mutableStateOf("") }
+                var response by remember { mutableStateOf("") }
+                val scope = rememberCoroutineScope()
+
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    OutlinedTextField(
+                        value = query,
+                        onValueChange = { query = it },
+                        label = { Text("Ask Gemini") },
+                        modifier = Modifier.fillMaxSize().weight(1f)
+                    )
+                    Button(onClick = {
+                        scope.launch {
+                            response = client.chat(query)
+                        }
+                    }) {
+                        Text("Send")
+                    }
+                    if (response.isNotBlank()) {
+                        Text(response)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/app/lawnchair/gemini/GeminiSpotlight.kt
+++ b/src/app/lawnchair/gemini/GeminiSpotlight.kt
@@ -1,0 +1,37 @@
+package app.lawnchair.gemini
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
+
+/**
+ * Lightweight composable showing a single suggestion from Gemini.
+ * Can be embedded on the home screen as a "Spotlight" section.
+ */
+@Composable
+fun GeminiSpotlight(query: String, modifier: Modifier = Modifier) {
+    val client = remember { GeminiClient() }
+    var suggestion by remember { mutableStateOf("") }
+    val scope = rememberCoroutineScope()
+
+    LaunchedEffect(query) {
+        scope.launch {
+            suggestion = client.spotlight(query)
+        }
+    }
+
+    if (suggestion.isNotBlank()) {
+        Card(modifier = modifier.fillMaxWidth().padding(16.dp)) {
+            Column(modifier = Modifier.padding(16.dp)) {
+                Text(text = suggestion, style = MaterialTheme.typography.bodyMedium)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Integrate Gemini chat activity using Compose and GeminiClient
- Provide lightweight Gemini spotlight composable for home screen suggestions
- Register Gemini chat activity in manifest

## Testing
- `./gradlew test` *(fails: Configuring project ':iconloaderlib' without an existing directory is not allowed)*

------
https://chatgpt.com/codex/tasks/task_e_68b21e8671388325887de9055ab3e16d