### PR TITLE
Remove unavailable Gemini dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -424,7 +424,6 @@ dependencies {
     implementation "com.squareup.retrofit2:retrofit:$retrofitVersion"
     implementation "com.squareup.retrofit2:converter-kotlinx-serialization:$retrofitVersion"
     implementation "com.squareup.okhttp3:okhttp:5.1.0"
-    implementation 'com.google.ai.client:generativeai:0.9.0'
 
     def roomVersion = '2.7.2'
     implementation "androidx.room:room-runtime:$roomVersion"

--- a/src/app/lawnchair/gemini/GeminiClient.kt
+++ b/src/app/lawnchair/gemini/GeminiClient.kt
@@ -1,36 +1,34 @@
 package app.lawnchair.gemini
 
-import com.google.ai.client.generativeai.GenerativeModel
-import com.google.ai.client.generativeai.type.Content
-import com.android.launcher3.BuildConfig
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 /**
  * Simple helper for interacting with Google's Gemini API.
- * Provides chat and spotlight style queries using the API key exposed via BuildConfig.
+ *
+ * The real implementation depends on Google AI's Generative AI client library, which is
+ * currently unavailable in the build. This stub keeps the project building while returning
+ * placeholder results.
  */
 class GeminiClient {
 
-    private val model = GenerativeModel(
-        modelName = "gemini-1.5-flash",
-        apiKey = BuildConfig.geminiKey,
-    )
-
     /**
      * Sends a chat prompt to Gemini and returns the plain text response.
+     *
+     * This stubbed version simply returns a message indicating the service is unavailable.
      */
-    suspend fun chat(prompt: String, history: List<Content> = emptyList()): String =
+    suspend fun chat(prompt: String, history: List<Any> = emptyList()): String =
         withContext(Dispatchers.IO) {
-            val chat = model.startChat(history = history)
-            chat.sendMessage(prompt).text.orEmpty()
+            "Gemini service unavailable"
         }
 
     /**
      * Runs a lightweight query intended for spotlight-style suggestions.
+     *
+     * The stub returns an empty string to indicate no suggestion is available.
      */
     suspend fun spotlight(query: String): String = withContext(Dispatchers.IO) {
-        model.generateContent(query).text.orEmpty()
+        ""
     }
 }
 


### PR DESCRIPTION
## Summary
- remove unresolvable Google AI generative AI dependency
- stub Gemini client to avoid build errors when library is absent

## Testing
- `./gradlew lint` *(fails: Configuring project ':iconloaderlib' without an existing directory is not allowed)*

------
https://chatgpt.com/codex/tasks/task_e_68b21f789c888325859767460357db18