### PR TITLE
Fix invalid escape sequences in translated strings

### DIFF
--- a/lawnchair/res/values-fr-rFR/strings.xml
+++ b/lawnchair/res/values-fr-rFR/strings.xml
@@ -54,7 +54,7 @@
     <string name="changes_dialog_build_format">Build n°%1$d → n°%2$d</string>
     <string name="changes_dialog_commit_info">par %1$s • %2$s • %3$s</string>
     <!-- Time ago strings -->
-    <string name="time_just_now">à l\'instant</string>
+    <string name="time_just_now">à l'instant</string>
     <string name="time_minutes_ago">%d min</string>
     <string name="time_hours_ago">%d h</string>
     <string name="time_days_ago">%d j</string>
@@ -64,7 +64,7 @@
     <string name="managed_by_lawnchair">Gérée par Assistant d'IA</string>
     <!-- When mentioning settings UI -->
     <string name="smartspace_preferences">Préférences</string>
-    <string name="settings_button_text">Paramètres de l\'accueil</string>
+    <string name="settings_button_text">Paramètres de l'accueil</string>
     <string name="system_settings">Paramètres du système</string>
     <string name="title_change_settings">Modifier les paramètres</string>
     <!--
@@ -82,22 +82,22 @@
     <!-- Relating to the Launcher ui -->
     <string name="columns">Colonnes</string>
     <string name="rows">Lignes</string>
-    <string name="label">Nom de l\'élément</string>
+    <string name="label">Nom de l'élément</string>
     <string name="icons">Icônes</string>
     <string name="grid">Grille</string>
     <string name="layout">Mise en page</string>
     <!-- Generic styling options -->
-    <string name="show_wallpaper">Afficher le fond d\'écran</string>
-    <string name="wallpaper">Fond d\'écran</string>
+    <string name="show_wallpaper">Afficher le fond d'écran</string>
+    <string name="wallpaper">Fond d'écran</string>
     <string name="style">Style</string>
-    <string name="background_opacity">Opacité de l\'arrière-plan</string>
+    <string name="background_opacity">Opacité de l'arrière-plan</string>
     <!-- Toast text and tips -->
     <string name="copied_toast">Copié dans le presse-papiers</string>
     <string name="calculator_search_result_copied_toast">Résultat copié dans le presse-papiers</string>
     <string name="item_removed">Élément supprimé</string>
     <!-- Miscellaneous -->
     <string name="what_to_show">Informations à afficher</string>
-    <string name="wallpapers">Fonds d\'écran</string>
+    <string name="wallpapers">Fonds d'écran</string>
     <string name="caddy_beta">Catégorisé (bêta)</string>
     <string name="caddy">Catégorisé</string>
     <string name="app_drawer_folder">Dossiers du tiroir des applis</string>
@@ -110,11 +110,11 @@
     <string name="delete_label">Supprimer</string>
     <string name="folder_list_note">Balayez vers la gauche pour modifier, balayez vers la droite pour supprimer, ou appuyez pour ajouter des éléments</string>
     <string name="apps_in_folder_label">Masquer les applis rangées dans un dossier</string>
-    <string name="apps_in_folder_description">Les applis assignées à un dossier sont exclues des listes d\'applis</string>
+    <string name="apps_in_folder_description">Les applis assignées à un dossier sont exclues des listes d'applis</string>
     <string name="folders_filter_duplicates">Afficher seulement les applis uniques</string>
     <string name="my_folder_label">Mon dossier</string>
     <!-- A11y description -->
-    <string name="accessibility_service_description">Pour effectuer certaines actions (telles que verrouiller votre téléphone) en un seul geste, Assistant d'IA a besoin des droits d\'accessibilité.\n\nMalgré que le privilège est accordé de force à tous les services d\'accessibilité, Assistant d'IA n\'observe pas les actions de l\'utilisateur et ignore tous les événements envoyés par le système.\n\nAfin de verrouiller votre téléphone ou ouvrir l\'écran Récents, Assistant d'IA utilise le service d\'accessibilité performGlobalAction.</string>
+    <string name="accessibility_service_description">Pour effectuer certaines actions (telles que verrouiller votre téléphone) en un seul geste, Assistant d'IA a besoin des droits d'accessibilité.\n\nMalgré que le privilège est accordé de force à tous les services d'accessibilité, Assistant d'IA n'observe pas les actions de l'utilisateur et ignore tous les événements envoyés par le système.\n\nAfin de verrouiller votre téléphone ou ouvrir l'écran Récents, Assistant d'IA utilise le service d'accessibilité performGlobalAction.</string>
     <string name="x_with_y_count">%1$s (%2$d)</string>
     <string name="x_by_y">%1$d x %2$d</string>
     <string name="x_and_y">%1$s et %2$s</string>
@@ -126,11 +126,11 @@
     -->
     <string name="settings">Paramètres</string>
     <string name="general_label">Général</string>
-    <string name="general_description">Couleurs, packs d\'icônes, pastilles de notification</string>
-    <string name="home_screen_label">Écran d\'accueil</string>
+    <string name="general_description">Couleurs, packs d'icônes, pastilles de notification</string>
+    <string name="home_screen_label">Écran d'accueil</string>
     <string name="home_screen_description">Flux, grille, icônes</string>
     <string name="dock_label">Dock</string>
-    <string name="dock_description">Barre de recherche, nombre d\'icônes</string>
+    <string name="dock_description">Barre de recherche, nombre d'icônes</string>
     <string name="app_drawer_label">Tiroir des applis</string>
     <string name="app_drawer_description">Applis masquées, nombre de colonnes, icônes</string>
     <string name="drawer_search_label">Recherche dans le tiroir</string>
@@ -140,30 +140,30 @@
     <string name="gestures_label">Gestes</string>
     <string name="gestures_description">Appuis et balayages</string>
     <string name="quickstep_label">Écran Récents</string>
-    <string name="quickstep_description">Bouton Tout effacer, rayon d\'angle</string>
+    <string name="quickstep_description">Bouton Tout effacer, rayon d'angle</string>
     <string name="about_label">À propos</string>
-    <string name="app_info_drop_target_label">Infos sur l\'appli</string>
+    <string name="app_info_drop_target_label">Infos sur l'appli</string>
     <string name="debug_restart_launcher">Redémarrer Assistant d'IA</string>
     <string name="experimental_features_label">Fonctionnalités expérimentales</string>
     <!-- Experimental features -->
     <string name="font_picker_label">Personnalisation de la police</string>
     <string name="font_picker_description">Certains textes restent inchangés</string>
     <string name="smartspace_calendar_label">Personnalisation du calendrier dans Aperçu</string>
-    <string name="smartspace_calendar_description">Autoriser l\'affichage de la date dans les systèmes de calendrier non grégoriens</string>
-    <string name="workspace_increase_max_grid_size_label">Augmenter la taille maximale de la grille de l\'écran d\'accueil</string>
+    <string name="smartspace_calendar_description">Autoriser l'affichage de la date dans les systèmes de calendrier non grégoriens</string>
+    <string name="workspace_increase_max_grid_size_label">Augmenter la taille maximale de la grille de l'écran d'accueil</string>
     <string name="workspace_increase_max_grid_size_description">Augmenter la taille maximale autorisée de la grille de 10 x 10 à 20 x 20</string>
     <string name="always_reload_icons_label">Toujours recharger les icônes</string>
-    <string name="always_reload_icons_description">Éviter d\'utiliser les icônes en cache provenant des packs d\'icônes</string>
+    <string name="always_reload_icons_description">Éviter d'utiliser les icônes en cache provenant des packs d'icônes</string>
     <string name="icon_swipe_gestures">Gestes de balayage des icônes</string>
     <string name="icon_swipe_gestures_description">Effectuez des actions en balayant les icônes vers la gauche ou vers la droite</string>
     <string name="show_deck_layout">Disposition Deck</string>
-    <string name="show_deck_layout_description">Affichez une option de disposition permettant de masquer le tiroir des applis et d\'ajouter automatiquement les nouvelles applis à l\'écran d\'accueil</string>
+    <string name="show_deck_layout_description">Affichez une option de disposition permettant de masquer le tiroir des applis et d'ajouter automatiquement les nouvelles applis à l'écran d'accueil</string>
     <string name="recents_lock_unlock">Verrouiller/déverrouiller</string>
-    <string name="recents_lock_unlock_description">Empêcher l\'appli sélectionnée d\'être fermée lors d\'un appui sur « Tout effacer »</string>
+    <string name="recents_lock_unlock_description">Empêcher l'appli sélectionnée d'être fermée lors d'un appui sur « Tout effacer »</string>
     <!--Overlay-->
     <string name="overlay_fade_in">Fondu</string>
     <string name="overlay_suck_in">Aspiration</string>
-    <string name="app_closing_animation">Animation lors de la fermeture d\'une appli</string>
+    <string name="app_closing_animation">Animation lors de la fermeture d'une appli</string>
     <string name="overlay_label">Superposition</string>
     <string name="overlay_none">Aucune</string>
     <!--
@@ -171,21 +171,21 @@
     Notifications
 
     -->
-    <string name="set_default_launcher_tip">Pour accéder aux raccourcis et à plus de fonctionnalités, définissez Assistant d'IA en tant que lanceur d\'applications par défaut</string>
+    <string name="set_default_launcher_tip">Pour accéder aux raccourcis et à plus de fonctionnalités, définissez Assistant d'IA en tant que lanceur d'applications par défaut</string>
     <string name="notification_dots">Pastilles de notification</string>
     <string name="show_notification_count">Afficher le compteur de notifications</string>
     <string name="notification_dots_color">Couleur des pastilles de notification</string>
     <string name="notification_dots_text_color">Couleur du compteur de notifications</string>
-    <string name="notification_dots_color_contrast_warning_always">Attention : il n\'y a pas assez de contraste entre la couleur de la pastille et celle du compteur</string>
-    <string name="notification_dots_color_contrast_warning_sometimes">Attention : il se peut qu\'il n\'y ait pas toujours assez de contraste entre la couleur de la pastille et celle du compteur</string>
+    <string name="notification_dots_color_contrast_warning_always">Attention : il n'y a pas assez de contraste entre la couleur de la pastille et celle du compteur</string>
+    <string name="notification_dots_color_contrast_warning_sometimes">Attention : il se peut qu'il n'y ait pas toujours assez de contraste entre la couleur de la pastille et celle du compteur</string>
     <!--
 
     Icons
 
     -->
     <!-- General strings -->
-    <string name="icon_style_label">Style d\'icône</string>
-    <string name="icon_shape_label">Forme d\'icône</string>
+    <string name="icon_style_label">Style d'icône</string>
+    <string name="icon_shape_label">Forme d'icône</string>
     <string name="icon_sizes">Taille des icônes</string>
     <string name="show_labels">Afficher le nom des éléments</string>
     <string name="label_size">Taille du nom des éléments</string>
@@ -196,7 +196,7 @@
     <string name="auto_adaptive_icons_label">Icônes adaptatives automatiques</string>
     <string name="auto_adaptive_icons_description">Pour toutes les icônes non-adaptatives</string>
     <string name="shadow_bg_icons_label">Afficher une ombre derrière les icônes</string>
-    <string name="background_lightness_label">Luminosité de l\'arrière-plan</string>
+    <string name="background_lightness_label">Luminosité de l'arrière-plan</string>
     <string name="adaptive_icon_background_description">Définissez la luminosité à 100 % pour obtenir un arrière-plan blanc</string>
     <string name="reset_custom_icons">Réinitialiser les icônes personnalisées</string>
     <string name="reset_custom_icons_confirmation">Toutes les icônes personnalisées seront réinitialisées. Voulez-vous continuer ?</string>
@@ -205,7 +205,7 @@
     <string name="icon_picker_reset_to_default">Réinitialiser</string>
     <string name="icon_pack_external_picker">Ouvrir le sélecteur externe</string>
     <string name="pick_icon_from_label">Choisir une icône parmi</string>
-    <string name="icon_picker_load_failed">Impossible de charger plus d\'icônes</string>
+    <string name="icon_picker_load_failed">Impossible de charger plus d'icônes</string>
     <!-- Icon shapes  -->
     <string name="icon_shape_system">Système</string>
     <string name="icon_shape_circle">Cercle</string>
@@ -226,10 +226,10 @@
     <string name="icon_shape_seven_sided_cookie">Cookie à sept côtés</string>
     <string name="icon_shape_arch">Arche</string>
     <!-- Custom icon shapes -->
-    <string name="custom_icon_shape">Forme d\'icône personnalisée</string>
-    <string name="custom_icon_shape_create">Créer une forme d\'icône personnalisée</string>
-    <string name="custom_icon_shape_edit">Modifier la forme d\'icône personnalisée</string>
-    <string name="custom_icon_shape_corner">Type d\'angle</string>
+    <string name="custom_icon_shape">Forme d'icône personnalisée</string>
+    <string name="custom_icon_shape_create">Créer une forme d'icône personnalisée</string>
+    <string name="custom_icon_shape_edit">Modifier la forme d'icône personnalisée</string>
+    <string name="custom_icon_shape_corner">Type d'angle</string>
     <string name="custom_icon_shape_corner_round">Arrondi</string>
     <string name="custom_icon_shape_corner_squircle">Lisse</string>
     <string name="custom_icon_shape_corner_cut">Coupé</string>
@@ -239,17 +239,17 @@
     <string name="custom_icon_shape_bottom_right">En bas à droite</string>
     <string name="export_to_clipboard">Exporter vers le presse-papier</string>
     <string name="import_from_clipboard">Importer depuis le presse-papier</string>
-    <string name="icon_shape_clipboard_import_error">Le presse-papier ne contient pas de forme d\'icône valide</string>
+    <string name="icon_shape_clipboard_import_error">Le presse-papier ne contient pas de forme d'icône valide</string>
     <!-- Icon pack settings -->
-    <string name="icon_pack">Pack d\'icônes</string>
+    <string name="icon_pack">Pack d'icônes</string>
     <string name="themed_icon_pack">Source des icônes à thème</string>
-    <string name="themed_icon_pack_tint">Appliquer la couleur d\'accentuation</string>
+    <string name="themed_icon_pack_tint">Appliquer la couleur d'accentuation</string>
     <string name="system_icons">Icônes du système</string>
     <string name="themed_icon_title">Icônes à thème</string>
     <string name="themed_icons_off_label">Désactivé</string>
-    <string name="themed_icons_home_label">Écran d\'accueil</string>
-    <string name="themed_icons_home_and_drawer_label">Écran d\'accueil et tiroir des applis</string>
-    <string name="lawnicons_not_installed_description">Aucun pack d\'icônes pris en charge</string>
+    <string name="themed_icons_home_label">Écran d'accueil</string>
+    <string name="themed_icons_home_and_drawer_label">Écran d'accueil et tiroir des applis</string>
+    <string name="lawnicons_not_installed_description">Aucun pack d'icônes pris en charge</string>
     <!-- Fonts -->
     <string name="pref_fonts_add_fonts">Ajouter des polices</string>
     <string name="pref_fonts_add_fonts_summary">Les polices sont prises en charge aux formats OTF et TTF</string>
@@ -280,7 +280,7 @@
     <string name="theme_light">Clair</string>
     <string name="theme_dark">Sombre</string>
     <string name="theme_system_default">Système</string>
-    <string name="theme_follow_wallpaper">En fonction du fond d\'écran</string>
+    <string name="theme_follow_wallpaper">En fonction du fond d'écran</string>
     <!-- Color style -->
     <string name="color_style_label">Style des couleurs</string>
     <string name="color_style_spritz">Spritz</string>
@@ -293,7 +293,7 @@
     <string name="color_style_monochromatic">Monochromatique</string>
     <!-- Accent color and color picker -->
     <string name="colors">Couleurs</string>
-    <string name="accent_color">Couleur d\'accentuation</string>
+    <string name="accent_color">Couleur d'accentuation</string>
     <string name="swatches">Échantillons</string>
     <string name="rgb">RVB</string>
     <string name="rgb_red">Rouge</string>
@@ -319,7 +319,7 @@
     <string name="smartspace_battery_charging">Recharge en cours</string>
     <string name="smartspace_battery_full">Chargé</string>
     <string name="smartspace_battery_low">Batterie faible</string>
-    <string name="battery_charging_percentage_charging_time">"%1$d% % — Chargé dans %2$s"</string>
+    <string name="battery_charging_percentage_charging_time">%1$d%% — Chargé dans %2$s</string>
     <string name="smartspace_widget">Aperçu</string>
     <string name="smartspace_widget_description">Informations à afficher</string>
     <!-- Data and time format settings -->
@@ -327,7 +327,7 @@
     <string name="smartspace_date_and_time">Date et heure</string>
     <string name="smartspace_date">Date</string>
     <string name="smartspace_time">Heure</string>
-    <string name="smartspace_time_format">Format de l\'heure</string>
+    <string name="smartspace_time_format">Format de l'heure</string>
     <string name="smartspace_time_follow_system">Utiliser le paramètre du système</string>
     <string name="smartspace_time_12_hour_format">Format 12 heures</string>
     <string name="smartspace_time_24_hour_format">Format 24 heures</string>
@@ -343,10 +343,10 @@
     <string name="smartspace_requires_setup">Appuyez pour configurer</string>
     <string name="event_provider_missing_notification_dots">Pour pouvoir utiliser <xliff:g example="My Provider" id="providerName">%1$s</xliff:g>, activez les pastilles de notification.</string>
     <!-- Toggle button for enabling Smartspace -->
-    <string name="smartspace_widget_toggle_label">Afficher sur l\'écran d\'accueil</string>
-    <string name="smartspace_widget_toggle_description">Aperçu peut être ajouté manuellement à l\'écran d\'accueil en plaçant le widget Assistant d'IA</string>
+    <string name="smartspace_widget_toggle_label">Afficher sur l'écran d'accueil</string>
+    <string name="smartspace_widget_toggle_description">Aperçu peut être ajouté manuellement à l'écran d'accueil en plaçant le widget Assistant d'IA</string>
     <!-- List of available providers -->
-    <string name="smartspace_mode_label">Fournisseur d\'Aperçu</string>
+    <string name="smartspace_mode_label">Fournisseur d'Aperçu</string>
     <string name="smartspace_mode_google">Google</string>
     <string name="smartspace_mode_google_search">Recherche Google</string>
     <!-- Miscellaneous Smartspace strings -->
@@ -383,7 +383,7 @@
     <string name="create_backup">Créer une sauvegarde</string>
     <string name="what_to_backup">Éléments à sauvegarder</string>
     <string name="backup_content_layout_and_settings">Mise en page et paramètres</string>
-    <string name="backup_content_wallpaper">Fond d\'écran</string>
+    <string name="backup_content_wallpaper">Fond d'écran</string>
     <string name="backup_create_success">Sauvegarde créée</string>
     <string name="backup_create_error">Échec de la création de la sauvegarde</string>
     <string name="restore_backup">Restaurer une sauvegarde</string>
@@ -405,22 +405,22 @@
     <string name="gesture_swipe_right">Balayage vers la droite</string>
     <string name="gesture_handler_no_op">Ne rien faire</string>
     <string name="gesture_handler_sleep">Mettre en veille</string>
-    <string name="gesture_handler_recents">Ouvrir l\'écran Récents</string>
+    <string name="gesture_handler_recents">Ouvrir l'écran Récents</string>
     <string name="gesture_handler_open_notifications">Ouvrir le panneau des notifications</string>
     <string name="gesture_handler_open_app_option">Ouvrir une appli</string>
     <string name="gesture_handler_open_app_config">Ouvrir %1$s</string>
     <string name="gesture_handler_open_app_drawer">Ouvrir le tiroir des applis</string>
-    <string name="gesture_handler_open_app_search">Ouvrir la recherche d\'applis</string>
+    <string name="gesture_handler_open_app_search">Ouvrir la recherche d'applis</string>
     <string name="gesture_handler_open_search">Ouvrir la recherche</string>
-    <string name="gesture_handler_open_assistant">Ouvrir l\'assistant</string>
+    <string name="gesture_handler_open_assistant">Ouvrir l'assistant</string>
     <string name="pick_app_for_gesture">Sélectionnez une appli</string>
-    <string name="dt2s_admin_hint_title">Autorisations d\'administration requises</string>
-    <string name="dt2s_admin_hint">Pour mettre en veille votre appareil à l\'aide d\'un double appui, définissez Assistant d'IA comme appli d\'administration de l\'appareil. Appuyez sur « Ouvrir les paramètres » puis appuyez sur « Activer l\'appli d\'administration de cet appareil. »</string>
-    <string name="dt2s_admin_warning">Vous ne pourrez plus mettre en veille votre appareil à l\'aide d\'un double appui.</string>
-    <string name="d2ts_recents_a11y_hint_title">Activez le service d\'accessibilité</string>
-    <string name="dt2s_a11y_hint">Pour mettre en veille votre appareil avec un double appui, activez le service d\'accessibilité Assistant d'IA. Appuyez sur « Ouvrir les paramètres », sélectionnez « Assistant d'IA » et activez « Utiliser Assistant d'IA ».\n\nAssistant d'IA utilise la méthode d\'accessibilité `performGlobalAction`. Il s\'agit d\'une autorisation sensible qui permet de suivre le comportement des autres applis, mais Assistant d'IA n\'est pas configuré de manière à utiliser ces fonctionnalités et ne reçoit donc aucun événement.</string>
+    <string name="dt2s_admin_hint_title">Autorisations d'administration requises</string>
+    <string name="dt2s_admin_hint">Pour mettre en veille votre appareil à l'aide d'un double appui, définissez Assistant d'IA comme appli d'administration de l'appareil. Appuyez sur « Ouvrir les paramètres » puis appuyez sur « Activer l'appli d'administration de cet appareil. »</string>
+    <string name="dt2s_admin_warning">Vous ne pourrez plus mettre en veille votre appareil à l'aide d'un double appui.</string>
+    <string name="d2ts_recents_a11y_hint_title">Activez le service d'accessibilité</string>
+    <string name="dt2s_a11y_hint">Pour mettre en veille votre appareil avec un double appui, activez le service d'accessibilité Assistant d'IA. Appuyez sur « Ouvrir les paramètres », sélectionnez « Assistant d'IA » et activez « Utiliser Assistant d'IA ».\n\nAssistant d'IA utilise la méthode d'accessibilité `performGlobalAction`. Il s'agit d'une autorisation sensible qui permet de suivre le comportement des autres applis, mais Assistant d'IA n'est pas configuré de manière à utiliser ces fonctionnalités et ne reçoit donc aucun événement.</string>
     <string name="dt2s_recents_warning_open_settings">Ouvrir les paramètres</string>
-    <string name="recents_a11y_hint">Pour utiliser Ouvrir l\'écran Récents, activez le service d\'accessibilité Assistant d'IA. Appuyez sur « Ouvrir les paramètres », sélectionnez « Assistant d'IA » et activez « Utiliser Assistant d'IA ».\n\nAssistant d'IA utilise la méthode d\'accessibilité `performGlobalAction`. Il s\'agit d\'une autorisation sensible qui permet de suivre le comportement des autres applis, mais Assistant d'IA n\'est pas configuré de manière à utiliser ces fonctionnalités et ne reçoit donc aucun événement.</string>
+    <string name="recents_a11y_hint">Pour utiliser Ouvrir l'écran Récents, activez le service d'accessibilité Assistant d'IA. Appuyez sur « Ouvrir les paramètres », sélectionnez « Assistant d'IA » et activez « Utiliser Assistant d'IA ».\n\nAssistant d'IA utilise la méthode d'accessibilité `performGlobalAction`. Il s'agit d'une autorisation sensible qui permet de suivre le comportement des autres applis, mais Assistant d'IA n'est pas configuré de manière à utiliser ces fonctionnalités et ne reçoit donc aucun événement.</string>
     <!--
 
     Bug reporting
@@ -429,10 +429,10 @@
     <string name="lawnchair_bug_report">Signalement de bug Assistant d'IA</string>
     <string name="crash_report_notif_title">%1$s a planté</string>
     <string name="action_upload_crash_report">Envoyer le journal de plantage</string>
-    <string name="action_upload_error">Échec de l\'envoi</string>
+    <string name="action_upload_error">Échec de l'envoi</string>
     <string name="dogbin_uploading">Envoi en cours…</string>
     <string name="bugreport_channel_name">Signalements de bug</string>
-    <string name="status_channel_name">État de l\'envoi</string>
+    <string name="status_channel_name">État de l'envoi</string>
     <string name="bugreport_group_summary">%d nouveaux signalements</string>
     <string name="bugreport_group_summary_multiple">Plusieurs nouveaux signalements</string>
     <!--
@@ -441,28 +441,28 @@
 
     -->
     <!-- General and home screen settings -->
-    <string name="home_screen_rotation_label">Rotation de l\'écran d\'accueil</string>
-    <string name="home_screen_rotation_description">Autoriser la rotation de l\'écran d\'accueil lorsque l\'appareil est tourné</string>
-    <string name="wallpaper_blur">Flouter le fond d\'écran (expérimental)</string>
+    <string name="home_screen_rotation_label">Rotation de l'écran d'accueil</string>
+    <string name="home_screen_rotation_description">Autoriser la rotation de l'écran d'accueil lorsque l'appareil est tourné</string>
+    <string name="wallpaper_blur">Flouter le fond d'écran (expérimental)</string>
     <string name="wallpaper_background_blur">Intensité du flou</string>
     <string name="wallpaper_background_blur_factor">Seuil factoriel</string>
     <string name="home_lawn_deck_label">Deck</string>
     <string name="home_lawn_deck_label_beta">Deck (bêta)</string>
-    <string name="home_lawn_deck_description">Accédez à vos applications sans effort avec Deck, l\'expérience sans tiroir d\'applis ultime, conçue pour une organisation simple et fluide de votre écran d\'accueil</string>
-    <string name="auto_add_shortcuts_label">Ajouter les nouvelles applis à l\'écran d\'accueil</string>
+    <string name="home_lawn_deck_description">Accédez à vos applications sans effort avec Deck, l'expérience sans tiroir d'applis ultime, conçue pour une organisation simple et fluide de votre écran d'accueil</string>
+    <string name="auto_add_shortcuts_label">Ajouter les nouvelles applis à l'écran d'accueil</string>
     <string name="minus_one_enable">Afficher le flux</string>
     <string name="minus_one_unavailable">Aucune appli de flux installée</string>
     <string name="minus_one">Flux</string>
     <string name="feed_provider">Fournisseur du flux</string>
-    <string name="wallpaper_scrolling_label">Faire défiler le fond d\'écran</string>
-    <string name="wallpaper_depth_effect_label">Effet de profondeur du fond d\'écran</string>
-    <string name="wallpaper_depth_effect_description">Zoom avant et arrière du fond d\'écran lors des transitions entre différentes zones du lanceur d\'applications</string>
+    <string name="wallpaper_scrolling_label">Faire défiler le fond d'écran</string>
+    <string name="wallpaper_depth_effect_label">Effet de profondeur du fond d'écran</string>
+    <string name="wallpaper_depth_effect_description">Zoom avant et arrière du fond d'écran lors des transitions entre différentes zones du lanceur d'applications</string>
     <string name="show_sys_ui_scrim">Ombre du haut</string>
-    <string name="home_screen_grid">Grille de l\'écran d\'accueil</string>
-    <string name="home_screen_lock">Verrouiller l\'écran d\'accueil</string>
-    <string name="home_screen_unlock">Déverrouiller l\'écran d\'accueil</string>
-    <string name="home_screen_locked">L\'écran d\'accueil est verrouillé</string>
-    <string name="home_screen_lock_description">Empêcher les changements d\'agencement de l\'écran d\'accueil</string>
+    <string name="home_screen_grid">Grille de l'écran d'accueil</string>
+    <string name="home_screen_lock">Verrouiller l'écran d'accueil</string>
+    <string name="home_screen_unlock">Déverrouiller l'écran d'accueil</string>
+    <string name="home_screen_locked">L'écran d'accueil est verrouillé</string>
+    <string name="home_screen_lock_description">Empêcher les changements d'agencement de l'écran d'accueil</string>
     <string name="show_dot_pagination_label">Afficher des points représentant les pages</string>
     <string name="show_dot_pagination_description">Utiliser des points plutôt que des lignes pour afficher le numéro de page</string>
     <string name="show_material_u_popup_label">Utiliser le nouveau style de pop-up</string>
@@ -470,12 +470,12 @@
     <string name="popup_menu">Menu pop-up</string>
     <string name="popup_menu_items">Éléments du menu pop-up</string>
     <string name="edit_menu_items">Modifier les éléments du menu pop-up</string>
-    <string name="wallpaper_quick_picker">Sélecteur rapide de fond d\'écran</string>
-    <string name="status_bar_label">Barre d\'état</string>
-    <string name="show_status_bar">Afficher la barre d\'état</string>
-    <string name="dark_status_bar_label">Barre d\'état sombre</string>
-    <string name="status_bar_clock_label">Horloge de la barre d\'état</string>
-    <string name="status_bar_clock_description">Masquer dynamiquement l\'horloge de la barre d\'état sur le premier écran</string>
+    <string name="wallpaper_quick_picker">Sélecteur rapide de fond d'écran</string>
+    <string name="status_bar_label">Barre d'état</string>
+    <string name="show_status_bar">Afficher la barre d'état</string>
+    <string name="dark_status_bar_label">Barre d'état sombre</string>
+    <string name="status_bar_clock_label">Horloge de la barre d'état</string>
+    <string name="status_bar_clock_description">Masquer dynamiquement l'horloge de la barre d'état sur le premier écran</string>
     <string name="home_screen_text_color">Couleur du texte</string>
     <string name="color_light">Clair</string>
     <string name="color_dark">Sombre</string>
@@ -493,31 +493,31 @@
     <string name="hotseat_mode_label">Widget Barre de recherche</string>
     <string name="hotseat_mode_disabled">Désactivé</string>
     <string name="hotseat_mode_google_search">Barre de recherche Google</string>
-    <string name="qsb_hotseat_background_transparency">Opacité de l\'arrière-plan</string>
+    <string name="qsb_hotseat_background_transparency">Opacité de l'arrière-plan</string>
     <string name="qsb_hotseat_stroke_width">Épaisseur du contour</string>
     <string name="qsb_hotseat_stroke_color">Couleur du contour</string>
-    <string name="corner_radius_label">Rayon d\'angle</string>
-    <string name="apply_accent_color_label">Appliquer la couleur d\'accentuation</string>
+    <string name="corner_radius_label">Rayon d'angle</string>
+    <string name="apply_accent_color_label">Appliquer la couleur d'accentuation</string>
     <string name="search_provider">Fournisseur des résultats de recherche</string>
-    <string name="hotseat_background">Afficher l\'arrière-plan</string>
+    <string name="hotseat_background">Afficher l'arrière-plan</string>
     <string name="hotseat_bg_horizontal_inset_left">Marge gauche</string>
     <string name="hotseat_bg_horizontal_inset_right">Marge droite</string>
     <string name="hotseat_bg_vertical_inset_top">Marge haut</string>
     <string name="hotseat_bg_vertical_inset_bottom">Marge bas</string>
-    <string name="hotseat_bg_color_label">Couleur d\'arrière-plan</string>
-    <string name="hotseat_bg_alpha">Opacité de l\'arrière-plan</string>
+    <string name="hotseat_bg_color_label">Couleur d'arrière-plan</string>
+    <string name="hotseat_bg_alpha">Opacité de l'arrière-plan</string>
     <!-- Pause apps shortcut -->
     <string name="pause">Suspendre</string>
     <string name="pause_apps_dialog_title">Suspendre %1$s ?</string>
     <string name="pause_apps_dialog_message">Les notifications de %1$s seront suspendues</string>
     <string name="paused_apps_dialog_title">Appli suspendue</string>
-    <string name="paused_apps_dialog_message">%1$s a été suspendu à partir du lanceur d\'applications</string>
-    <string name="paused_apps_drop_target_label">Suspendre l\'appli</string>
+    <string name="paused_apps_dialog_message">%1$s a été suspendu à partir du lanceur d'applications</string>
+    <string name="paused_apps_drop_target_label">Suspendre l'appli</string>
     <string name="dock_icons">Icônes dans le dock</string>
     <string name="hotseat_bottom_space_label">Décalage vers le haut</string>
-    <string name="page_indicator_height">Hauteur de l\'indicateur de page</string>
+    <string name="page_indicator_height">Hauteur de l'indicateur de page</string>
     <!-- Search providers -->
-    <string name="search_provider_app_search">Recherche d\'applis</string>
+    <string name="search_provider_app_search">Recherche d'applis</string>
     <string name="search_provider_custom">Personnalisé</string>
     <string name="search_provider_sponsored_description">%1$s et Assistant d'IA ont signé un accord de partage des revenus.\n\nEn effectuant vos recherches avec %1$s, vous soutenez Assistant d'IA.</string>
     <string name="app_label">Application</string>
@@ -530,14 +530,14 @@
     <!-- App drawer settings -->
     <string name="hidden_apps_label">Applis masquées</string>
     <string name="pref_all_apps_bulk_icon_loading_title">Charger plusieurs applis à la fois</string>
-    <string name="pref_all_apps_bulk_icon_loading_description">Charger et afficher les icônes de plusieurs applications à la fois plutôt qu\'une par une</string>
+    <string name="pref_all_apps_bulk_icon_loading_description">Charger et afficher les icônes de plusieurs applications à la fois plutôt qu'une par une</string>
     <string name="pref_all_apps_remember_position_title">Mémoriser la position</string>
-    <string name="pref_all_apps_remember_position_description">Mémoriser la position du tiroir des applis après l\'avoir fermé</string>
+    <string name="pref_all_apps_remember_position_description">Mémoriser la position du tiroir des applis après l'avoir fermé</string>
     <string name="pref_all_apps_show_scrollbar_title">Afficher la barre de défilement</string>
     <string name="app_drawer_columns">Colonnes du tiroir des applis</string>
     <string name="row_height_label">Hauteur de ligne</string>
     <string name="app_drawer_indent_label">Décalage vers le centre</string>
-    <string name="app_drawer_bg_color_label">Couleur d\'arrière-plan</string>
+    <string name="app_drawer_bg_color_label">Couleur d'arrière-plan</string>
     <!-- HiddenAppsPreferences -->
     <string name="hide_from_drawer">Masquer dans le tiroir des applis</string>
     <string name="hidden_apps_label_with_count">Applis masquées (%1$d)</string>
@@ -547,24 +547,24 @@
     </plurals>
     <!-- Folder settings -->
     <string name="folder_preview_bg_opacity_label">Opacité arrière-plan aperçu icônes</string>
-    <string name="folder_bg_opacity_label">Opacité de l\'arrière-plan des dossiers</string>
-    <string name="folder_preview_bg_color_label">Couleur de l\'arrière-plan des icônes</string>
+    <string name="folder_bg_opacity_label">Opacité de l'arrière-plan des dossiers</string>
+    <string name="folder_preview_bg_color_label">Couleur de l'arrière-plan des icônes</string>
     <string name="max_folder_columns">Colonnes max. dans les dossiers</string>
     <string name="max_folder_rows">Lignes max. dans les dossiers</string>
     <!-- Quickstep settings -->
-    <string name="quickswitch_ignored_warning">Ces paramètres seront ignorés car Assistant d'IA n\'est pas défini comme fournisseur d\'écran Récents</string>
+    <string name="quickswitch_ignored_warning">Ces paramètres seront ignorés car Assistant d'IA n'est pas défini comme fournisseur d'écran Récents</string>
     <string name="quickstep_incompatible">Intégration système incompatible</string>
-    <string name="quickstep_incompatible_description">Votre appareil est configuré pour que la navigation par gestes (appelée Quickstep) soit fournie par %1$s, mais la version installée n\'est pas compatible avec votre version d\'Android. Pour continuer à utiliser votre appareil, désinstallez les mises à jour de %1$s ou désactivez-le en tant que fournisseur système de navigation par gestes.</string>
+    <string name="quickstep_incompatible_description">Votre appareil est configuré pour que la navigation par gestes (appelée Quickstep) soit fournie par %1$s, mais la version installée n'est pas compatible avec votre version d'Android. Pour continuer à utiliser votre appareil, désinstallez les mises à jour de %1$s ou désactivez-le en tant que fournisseur système de navigation par gestes.</string>
     <string name="translucent_background">Arrière-plan translucide</string>
-    <string name="translucent_background_alpha">Opacité de l\'arrière-plan</string>
+    <string name="translucent_background_alpha">Opacité de l'arrière-plan</string>
     <string name="recents_actions_label">Actions rapides</string>
     <string name="action_share">Partager</string>
     <string name="action_lens">Lens</string>
     <string name="recents_clear_all">Tout effacer</string>
-    <string name="task_menu_force_stop">Forcer l\'arrêt</string>
-    <string name="window_corner_radius_label">Rayon d\'angle de l\'écran</string>
-    <string name="override_window_corner_radius_label">Rayon d\'angle de l\'écran personnalisé</string>
-    <string name="window_corner_radius_description">Lorsque vous balayez l\'écran vers le haut pour ouvrir l\'écran Récents, l\'appli ouverte suit votre doigt et devient une carte dont la taille diminue progressivement. Utilisez ce curseur pour ajuster le rayon des angles de la carte afin qu\'ils correspondent aux coins de votre écran.</string>
+    <string name="task_menu_force_stop">Forcer l'arrêt</string>
+    <string name="window_corner_radius_label">Rayon d'angle de l'écran</string>
+    <string name="override_window_corner_radius_label">Rayon d'angle de l'écran personnalisé</string>
+    <string name="window_corner_radius_description">Lorsque vous balayez l'écran vers le haut pour ouvrir l'écran Récents, l'appli ouverte suit votre doigt et devient une carte dont la taille diminue progressivement. Utilisez ce curseur pour ajuster le rayon des angles de la carte afin qu'ils correspondent aux coins de votre écran.</string>
     <string name="taskbar_label">Barre des tâches</string>
     <string name="enable_taskbar_experimental">Afficher la barre des tâches (expérimental)</string>
     <!--
@@ -575,36 +575,36 @@
     <!-- Launcher strings used -->
     <string name="all_apps_device_search_hint">Recherche Web/applis</string>
     <string name="all_apps_search_bar_hint">Rechercher des applis</string>
-    <string name="all_apps_no_search_results">Aucune application correspondant à « <xliff:g example="Android" id="query">%1$s</xliff:g> » n\'a pu être trouvée</string>
+    <string name="all_apps_no_search_results">Aucune application correspondant à « <xliff:g example="Android" id="query">%1$s</xliff:g> » n'a pu être trouvée</string>
     <string name="all_apps_search_result_suggestions">Depuis le Web</string>
-    <string name="all_apps_search_result_contacts_from_device">Contacts de l\'appareil</string>
-    <string name="all_apps_search_result_files">Fichiers de l\'appareil</string>
-    <string name="all_apps_search_result_settings_entry_from_device">Paramètres de l\'appareil</string>
-    <string name="all_apps_search_market_message">Rechercher plus d\'applis</string>
+    <string name="all_apps_search_result_contacts_from_device">Contacts de l'appareil</string>
+    <string name="all_apps_search_result_files">Fichiers de l'appareil</string>
+    <string name="all_apps_search_result_settings_entry_from_device">Paramètres de l'appareil</string>
+    <string name="all_apps_search_market_message">Rechercher plus d'applis</string>
     <string name="all_apps_search_on_web_message">Rechercher avec <xliff:g example="Startpage" id="web_search_provider">%1$s</xliff:g></string>
-    <string name="error_no_market_or_browser_installed">Aucun magasin d\'applis ni navigateur installé</string>
+    <string name="error_no_market_or_browser_installed">Aucun magasin d'applis ni navigateur installé</string>
     <string name="all_apps_search_on_web_general">Rechercher sur le Web</string>
-    <string name="clear_history">Effacer l\'historique des recherches</string>
+    <string name="clear_history">Effacer l'historique des recherches</string>
     <string name="search_input_action_clear_results">Effacer la barre de recherche</string>
     <!-- Search settings -->
     <string name="pref_category_search">Recherche</string>
     <string name="show_app_search_bar">Afficher la barre de recherche</string>
     <string name="pref_search_auto_show_keyboard">Afficher le clavier automatiquement</string>
     <string name="fuzzy_search_title">Recherche approximative</string>
-    <string name="fuzzy_search_desc">Correspondance approximative pour les recherches d\'applis</string>
+    <string name="fuzzy_search_desc">Correspondance approximative pour les recherches d'applis</string>
     <string name="suggestion_pref_screen_title">Suggestions</string>
     <string name="show_suggested_apps_at_drawer_top">Afficher des applis suggérées en haut du tiroir</string>
-    <string name="perform_wide_search_title">Recherche sur l\'appareil</string>
+    <string name="perform_wide_search_title">Recherche sur l'appareil</string>
     <string name="perform_wide_search_description">Recherchez parmi les contacts, fichiers et paramètres de votre téléphone</string>
     <string name="show_hidden_apps_in_search_results">Faire apparaître les applis masquées dans les résultats de recherche</string>
     <string name="hidden_apps_show_name_typed">Si le nom complet est saisi</string>
     <string name="allapps_web_suggestion_provider_label">Fournisseur de suggestions Web</string>
-    <string name="allapps_use_web_suggestion_icon_label">Afficher l\'icône du fournisseur de suggestions Web dans la barre de recherche</string>
+    <string name="allapps_use_web_suggestion_icon_label">Afficher l'icône du fournisseur de suggestions Web dans la barre de recherche</string>
     <string name="allapps_match_qsb_style_label">Utiliser les actions de la barre de recherche du dock</string>
-    <string name="allapps_match_qsb_style_description">Appuyer sur la barre de recherche du dock ouvrira désormais l\'interface de recherche du tiroir des applis</string>
+    <string name="allapps_match_qsb_style_description">Appuyer sur la barre de recherche du dock ouvrira désormais l'interface de recherche du tiroir des applis</string>
     <string name="app_search_algorithm">Algorithme de recherche</string>
-    <string name="search_algorithm_app_search">Recherche d\'applications</string>
-    <string name="search_algorithm_global_search_on_device">Recherche globale (sur l\'appareil)</string>
+    <string name="search_algorithm_app_search">Recherche d'applications</string>
+    <string name="search_algorithm_global_search_on_device">Recherche globale (sur l'appareil)</string>
     <string name="search_algorithm_global_search_via_asi">Recherche globale (via ASI)</string>
     <string name="custom_search_label">Nom du moteur de recherche</string>
     <string name="custom_search_url">URL du moteur de recherche</string>
@@ -614,7 +614,7 @@
     <!-- Labels of each search result types -->
     <string name="show_search_result_types">Afficher dans les résultats de recherche</string>
     <string name="search_pref_result_apps_and_shortcuts_title">Applis et raccourcis</string>
-    <string name="search_pref_result_shortcuts_title">Raccourcis d\'applis</string>
+    <string name="search_pref_result_shortcuts_title">Raccourcis d'applis</string>
     <string name="search_pref_result_people_title">Personnes</string>
     <string name="search_pref_result_tips_title">Astuces Pixel</string>
     <string name="search_pref_result_settings_title">Paramètres Android</string>
@@ -634,41 +634,41 @@
     <string name="search_pref_result_contacts_description">Contacts et autres</string>
     <string name="search_pref_result_web_provider_description">Via <xliff:g id="web_search_provider">%1$s</xliff:g></string>
     <!-- Maximum xyz for each search result type -->
-    <string name="max_apps_result_count_title">Nombre maximal d\'applis</string>
+    <string name="max_apps_result_count_title">Nombre maximal d'applis</string>
     <string name="max_people_result_count_title">Nombre maximal de personnes</string>
     <string name="max_file_result_count_title">Nombre maximal de fichiers</string>
     <string name="max_settings_entry_result_count_title">Nombre maximal de paramètres</string>
-    <string name="max_recent_result_count_title">Éléments max. de l\'historique des recherches</string>
+    <string name="max_recent_result_count_title">Éléments max. de l'historique des recherches</string>
     <string name="max_suggestion_result_count_title">Nombre maximal de suggestions</string>
     <string name="max_web_suggestion_delay">Délai maximal des suggestions Web</string>
     <!-- Permission management -->
     <string name="missing_notification_access_label">Accès aux notifications requis</string>
-    <string name="missing_notification_access_desc">Pour afficher les pastilles de notification, activez les notifications de l\'appli <xliff:g id="name" example="My App">%1$s</xliff:g></string>
+    <string name="missing_notification_access_desc">Pour afficher les pastilles de notification, activez les notifications de l'appli <xliff:g id="name" example="My App">%1$s</xliff:g></string>
     <string name="warn_contact_permission_title">Autorisation Contacts nécessaire</string>
     <string name="warn_contact_permission_content">Pour rechercher des contacts, accordez les autorisations Contacts et Téléphone à <xliff:g id="name" example="My App">%1$s</xliff:g></string>
     <string name="permissions_music_audio">Accès Musique et audio nécessaire</string>
-    <string name="permissions_music_audio_description">Pour rechercher votre musique et d\'autres fichiers audio, <xliff:g id="name" example="My App">%1$s</xliff:g> a besoin de votre autorisation pour accéder à votre bibliothèque multimédia.</string>
+    <string name="permissions_music_audio_description">Pour rechercher votre musique et d'autres fichiers audio, <xliff:g id="name" example="My App">%1$s</xliff:g> a besoin de votre autorisation pour accéder à votre bibliothèque multimédia.</string>
     <!-- Photos and videos -->
     <string name="permissions_photos_videos">Accès Photos et vidéos nécessaire</string>
-    <string name="permissions_photos_videos_description">Pour rechercher dans vos photos et vidéos, <xliff:g id="name" example="My App">%1$s</xliff:g> a besoin d\'accéder à votre bibliothèque multimédia.</string>
+    <string name="permissions_photos_videos_description">Pour rechercher dans vos photos et vidéos, <xliff:g id="name" example="My App">%1$s</xliff:g> a besoin d'accéder à votre bibliothèque multimédia.</string>
     <string name="permissions_photos_videos_full">Accéder à votre bibliothèque multimédia complète ?</string>
-    <string name="permissions_photos_videos_full_description">Pour rechercher dans toutes vos photos et vidéos, <xliff:g id="name" example="My App">%1$s</xliff:g> a besoin d\'un accès complet à votre bibliothèque multimédia.</string>
+    <string name="permissions_photos_videos_full_description">Pour rechercher dans toutes vos photos et vidéos, <xliff:g id="name" example="My App">%1$s</xliff:g> a besoin d'un accès complet à votre bibliothèque multimédia.</string>
     <string name="permissions_photos_videos_grant_full">Accorder toutes les autorisations multimédia</string>
     <string name="permissions_photos_videos_manage_selected">Gérer les éléments sélectionnés</string>
     <!-- External storage -->
     <string name="permissions_external_storage">Accès au stockage externe nécessaire</string>
-    <string name="permissions_external_storage_description">Pour rechercher dans vos fichiers, <xliff:g id="name" example="My App">%1$s</xliff:g> a besoin d\'accéder au stockage externe de votre appareil.</string>
+    <string name="permissions_external_storage_description">Pour rechercher dans vos fichiers, <xliff:g id="name" example="My App">%1$s</xliff:g> a besoin d'accéder au stockage externe de votre appareil.</string>
     <string name="permissions_manage_storage">Accès à tous les fichiers nécessaire</string>
-    <string name="permissions_manage_storage_description">Pour afficher vos fichiers dans les résultats de recherche, <xliff:g id="name" example="My App">%1$s</xliff:g> requiert l\'autorisation de gérer tous les fichiers sur votre appareil. Cette autorisation est utilisée exclusivement afin de lister les fichiers et ne sera pas utilisée pour lire ou modifier le contenu de vos fichiers personnels.</string>
-    <string name="permission_desc_wallpaper_base">Pour afficher des aperçus de votre fond d\'écran actuel et les inclure dans les sauvegardes, <xliff:g id="name" example="My App">%1$s</xliff:g> requiert l\'autorisation %2$s en raison de limitations système relatives à l\'accès aux données de fond d\'écran.</string>
+    <string name="permissions_manage_storage_description">Pour afficher vos fichiers dans les résultats de recherche, <xliff:g id="name" example="My App">%1$s</xliff:g> requiert l'autorisation de gérer tous les fichiers sur votre appareil. Cette autorisation est utilisée exclusivement afin de lister les fichiers et ne sera pas utilisée pour lire ou modifier le contenu de vos fichiers personnels.</string>
+    <string name="permission_desc_wallpaper_base">Pour afficher des aperçus de votre fond d'écran actuel et les inclure dans les sauvegardes, <xliff:g id="name" example="My App">%1$s</xliff:g> requiert l'autorisation %2$s en raison de limitations système relatives à l'accès aux données de fond d'écran.</string>
     <string name="permission_desc_ending_read_all_files">de lire tous les fichiers sur votre appareil</string>
     <string name="permission_desc_ending_manage_all_files">de gérer tous les fichiers sur votre appareil</string>
     <string name="permission_desc_wallpaper_multiple">Plusieurs autorisations nécessaires</string>
-    <string name="permission_desc_wallpaper_multiple_desc">Pour afficher des aperçus de votre fond d\'écran actuel et les inclure dans les sauvegardes, <xliff:g id="name" example="My App">%1$s</xliff:g> requiert les autorisations suivantes en raison de limitations système relatives à l\'accès aux données de fond d\'écran.</string>
-    <string name="permission_label_manage_all_files">Gérer tous les fichiers sur l\'appareil</string>
+    <string name="permission_desc_wallpaper_multiple_desc">Pour afficher des aperçus de votre fond d'écran actuel et les inclure dans les sauvegardes, <xliff:g id="name" example="My App">%1$s</xliff:g> requiert les autorisations suivantes en raison de limitations système relatives à l'accès aux données de fond d'écran.</string>
+    <string name="permission_label_manage_all_files">Gérer tous les fichiers sur l'appareil</string>
     <string name="permission_label_read_photos_videos">Lire les photos et les vidéos</string>
-    <string name="manage_storage_access_denied_title">Impossible d\'activer l\'accès à tous les fichiers</string>
-    <string name="manage_storage_access_denied_description">En raison de la politique du Play Store, <xliff:g id="name" example="My App">%1$s</xliff:g> ne peut pas demander un accès complet au stockage. Pour accéder à tous les fichiers, veuillez télécharger <xliff:g id="name" example="My App">%1$s</xliff:g> depuis GitHub. Vous pouvez également accorder l\'accès aux photos, vidéos et fichiers audio individuellement dans les paramètres.</string>
+    <string name="manage_storage_access_denied_title">Impossible d'activer l'accès à tous les fichiers</string>
+    <string name="manage_storage_access_denied_description">En raison de la politique du Play Store, <xliff:g id="name" example="My App">%1$s</xliff:g> ne peut pas demander un accès complet au stockage. Pour accéder à tous les fichiers, veuillez télécharger <xliff:g id="name" example="My App">%1$s</xliff:g> depuis GitHub. Vous pouvez également accorder l'accès aux photos, vidéos et fichiers audio individuellement dans les paramètres.</string>
     <string name="open_permission_settings">Ouvrir les paramètres</string>
     <string name="grant_requested_permissions">Accorder des autorisations</string>
     <string name="permissions_needed">Autorisations nécessaires</string>

--- a/lawnchair/res/values-pl-rPL/strings.xml
+++ b/lawnchair/res/values-pl-rPL/strings.xml
@@ -662,7 +662,7 @@
     <string name="permissions_external_storage_description">Aby wyszukiwać Twoje pliki, <xliff:g id="name" example="My App">%1$s</xliff:g> potrzebuje uprawnienia dostępu do pamięci zewnętrznej Twojego urządzenia.</string>
     <string name="permissions_manage_storage">Wymagany dostęp do pamięci zewnętrznej</string>
     <string name="permissions_manage_storage_description">Aby wyświetlać Twoje pliki w wynikach wyszukiwania, <xliff:g id="name" example="My App">%1$s</xliff:g> wymaga uprawnienia do zarządzania wszystkimi plikami na Twoim urządzeniu. To uprawnienie służy wyłącznie do wyświetlania listy plików i nie będzie używane do odczytywania ani zmieniania zawartości Twoich plików osobistych.</string>
-    <string name="permission_desc_wallpaper_base">Aby wyświetlać podglądy tapet oraz uwzględniać je w kopiach zapasowych, &lt;xliff:g id="name" example="My App"&gt;%1s\&lt;/xliff:g\&gt; wymaga uprawnienia %2s. Wynika to z ograniczeń systemowych dotyczących dostępu do danych tapety.</string>
+    <string name="permission_desc_wallpaper_base">Aby wyświetlać podglądy tapet oraz uwzględniać je w kopiach zapasowych, <xliff:g id="name" example="My App">%1$s</xliff:g> wymaga uprawnienia %2$s. Wynika to z ograniczeń systemowych dotyczących dostępu do danych tapety.</string>
     <string name="permission_desc_ending_read_all_files">aby odczytać wszystkie pliki na Twoim urządzeniu</string>
     <string name="permission_desc_ending_manage_all_files">aby zarządzać wszystkimi plikami na twoim urządzeniu</string>
     <string name="permission_desc_wallpaper_multiple">Wymagane jest wiele uprawnień</string>


### PR DESCRIPTION
## Summary
- remove stray escape characters from French strings
- correct placeholders in French battery charging message
- fix Polish wallpaper permission description formatting

## Testing
- `./gradlew -p lawnchair lintVitalRelease` *(fails: Configuring project ':iconloaderlib' without an existing directory is not allowed)*

------
https://chatgpt.com/codex/tasks/task_e_68b221733668832593c87ad79305730d