### PR TITLE
Sync Spotlight widget with Gemini responses

### DIFF
--- a/aiasistent/main/java/cz/appkazdarma/aiasistent/presentation/home/HomeViewModel.kt
+++ b/aiasistent/main/java/cz/appkazdarma/aiasistent/presentation/home/HomeViewModel.kt
@@ -1,6 +1,7 @@
 package cz.appkazdarma.aiasistent.presentation.home
 
 import android.content.Context
+import android.content.Intent
 import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
@@ -64,7 +65,7 @@ class HomeViewModel @Inject constructor(
     private val _eventFlow = MutableSharedFlow<HomeUIEvent>()
     val eventFlow = _eventFlow
 
-    fun updateContents() {
+    fun updateContents(context: Context) {
         val currentTime = System.currentTimeMillis()
         val timeSinceLastUpdate = currentTime - lastUpdate
 
@@ -75,7 +76,7 @@ class HomeViewModel @Inject constructor(
 
             viewModelScope.launch(Dispatchers.IO) {
                 updateWeatherWidget()
-                updateGeminiResponse()
+                updateGeminiResponse(context)
             }
         }
     }
@@ -108,18 +109,28 @@ class HomeViewModel @Inject constructor(
         return getApp(packageName, StringType.APP_PACKAGE_NAME)
     }
 
-    private suspend fun updateGeminiResponse() {
+    private suspend fun updateGeminiResponse(context: Context) {
         geminiJob?.cancel()
         _geminiState.value = Resource.Loading()
 
         val (prompt, history) = getGeminiPrompt()
 
-        // can be improved
         geminiJob = getGeminiResponse(prompt, history)
             .onEach { result ->
                 _geminiState.value = when (result) {
-                    is Resource.Success -> Resource.Success(result.data as GeminiItem)
+                    is Resource.Success -> {
+                        val item = result.data as GeminiItem
+                        // save the latest response for the widget and request widget update
+                        context.getSharedPreferences("widget_prefs", Context.MODE_PRIVATE)
+                            .edit()
+                            .putString("spotlight_content", item.response)
+                            .apply()
+                        context.sendBroadcast(Intent("cz.appkazdarma.aiasistent.ACTION_UPDATE_WIDGET"))
+                        Resource.Success(item)
+                    }
+
                     is Resource.Loading -> Resource.Loading(result.data)
+
                     is Resource.Error -> {
                         result.message?.let { message ->
                             _eventFlow.emit(HomeUIEvent.ShowSnackbar(message))

--- a/aiasistent/main/java/cz/appkazdarma/aiasistent/presentation/home/components/HomeScreen.kt
+++ b/aiasistent/main/java/cz/appkazdarma/aiasistent/presentation/home/components/HomeScreen.kt
@@ -60,7 +60,7 @@ fun HomeScreen(
     val context = LocalContext.current
 
     LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
-        viewModel.updateContents()
+        viewModel.updateContents(context)
     }
 
     LaunchedEffect(viewModel) {
@@ -79,7 +79,7 @@ fun HomeScreen(
                         SnackbarResult.Dismissed -> Unit
                         SnackbarResult.ActionPerformed -> {
                             viewModel.resetLastUpdate()
-                            viewModel.updateContents()
+                            viewModel.updateContents(context)
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- Save latest Gemini summary for Spotlight widget and broadcast updates
- Pass context into home refresh to update widget state

## Testing
- ⚠️ `./gradlew lint` *(fails: Configuring project ':iconloaderlib' without an existing directory is not allowed)*

------
https://chatgpt.com/codex/tasks/task_e_68b22529a80c8325b2506f3b6a22a812